### PR TITLE
Migration generator fixes.

### DIFF
--- a/src/views/generators/migration.blade.php
+++ b/src/views/generators/migration.blade.php
@@ -37,6 +37,8 @@ class EntrustSetupTables extends Migration {
         {
             $table->increments('id');
             $table->string('name');
+            $table->string('display_name');
+            $table->timestamps();
         });
 
         // Creates the permission_role (Many-to-Many relation) table


### PR DESCRIPTION
Even though JSON permission handling is being phased out, I still had issues seeding my database (even though I wasn't using the JSON method). I recieved: 

```
  [Exception]
  SQLSTATE[42S22]: Column not found: 1054 Unknown column 'permissions' in 'field list' (SQL: insert into `roles` (`name`, `permissions`, `updated_at`, `created_at`) values (?, ?, ?, ?)) (Bindings: array (
    0 => 'Authorized',
    1 => 'null',
    2 => '2013-05-25 06:26:52',
    3 => '2013-05-25 06:26:52',
  ))

```
