### PR TITLE
Changed 'return_value'  key to 'return_type' in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Here's an example output.
 ```php
 $options = array(
 'validate_all' => true,
-'return_value' => 'both'
+'return_type' => 'both'
 );
 list($validate,$allValidations) = $user->ability(array('Admin','Owner'), array('manage_posts','manage_users'), $options);
 


### PR DESCRIPTION
The `ability()` example in the README that uses the `$options` array had an incorrect key. Changed it from `return_value` to `return_type` 
