### PR TITLE
Added __NAMESPACE__ to HasRoles trait and EntrustRole class to make the ...

### DIFF
--- a/src/Zizaco/Entrust/EntrustRole.php
+++ b/src/Zizaco/Entrust/EntrustRole.php
@@ -4,6 +4,13 @@ use LaravelBook\Ardent\Ardent;
 
 class EntrustRole extends Ardent
 {
+    /**
+     * The namespace of the user, role, and permissions.
+     * This assumes they are all in the same namespace.
+     *
+     * @var string
+     */
+    protected $namespace = '';
 
     /**
      * The database table used by the model.
@@ -26,7 +33,7 @@ class EntrustRole extends Ardent
      */
     public function users()
     {
-        return $this->belongsToMany(__NAMESPACE__ . '\User', 'assigned_roles');
+        return $this->belongsToMany($this->namespace . '\User', 'assigned_roles');
     }
 
     /**
@@ -38,7 +45,7 @@ class EntrustRole extends Ardent
         // To maintain backwards compatibility we'll catch the exception if the Permission table doesn't exist.
         // TODO remove in a future version
         try {
-            return $this->belongsToMany(__NAMESPACE__ . '\Permission');
+            return $this->belongsToMany($this->namespace . '\Permission');
         } catch(Execption $e) {}
     }
 

--- a/src/Zizaco/Entrust/HasRole.php
+++ b/src/Zizaco/Entrust/HasRole.php
@@ -9,7 +9,13 @@ trait HasRole
      */
     public function roles()
     {
-        return $this->belongsToMany(__NAMESPACE__ . '\Role', 'assigned_roles');
+        $namespace = '';
+
+        if (isset($this->namespace)) {
+            $namespace = $this->namespace;
+        }
+
+        return $this->belongsToMany($namespace . '\Role', 'assigned_roles');
     }
 
     /**


### PR DESCRIPTION
When working with this package, I gave my models a namespace of `App\Models`.  I figured this was par for the course when working with Laravel to keep my Models from interfering with other Models.  When I tried to add roles to my user model and such, it through an error saying it couldn't find a `Role` class.  After some digging, I realized it was coded under the impression that no one would namespace their models.  I made a quick change to the relationship function in the `HasRole` trait and the `EntrustRole` Model to allow for someone to namespace their models.  This does assume that the `Role`, `Permission`, and `User` model are all in the same namespace.  However, I feel this is a safe assumption.
