### PR TITLE
Amended migration to drop foreign keys before dropping tables

### DIFF
--- a/src/views/generators/migration.blade.php
+++ b/src/views/generators/migration.blade.php
@@ -1,6 +1,7 @@
 {{ '<?php' }}
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
 
 class EntrustSetupTables extends Migration {
 
@@ -57,6 +58,16 @@ class EntrustSetupTables extends Migration {
      */
     public function down()
     {
+        Schema::table('assigned_roles', function(Blueprint $table) {
+            $table->dropForeign('assigned_roles_user_id_foreign');
+            $table->dropForeign('assigned_roles_role_id_foreign');
+        });
+
+        Schema::table('permission_role', function(Blueprint $table) {
+            $table->dropForeign('permission_role_permission_id_foreign');
+            $table->dropForeign('permission_role_role_id_foreign');
+        });
+
         Schema::drop('assigned_roles');
         Schema::drop('permission_role');
         Schema::drop('roles');


### PR DESCRIPTION
I found that when you rolled back _after_ you had added data to Entrust's schema, you get a foreign key constraint error. Amending the migration to drop the keys before the tables appears to resolve this.
