### PR TITLE
Fixed a typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Entrust::routeNeedsPermission( 'admin/post*', array('manage_posts','manage_comme
 Entrust::routeNeedsRole( 'admin/advanced*', array('Owner','Writer') );
 ```
 
-Both of these methods accepts a third parameter. If the third parameter is null then the return of a prohibited access will be `App::abort(404)`. Otherwise the third parameter will be returned. So you can use it like:
+Both of these methods accepts a third parameter. If the third parameter is null then the return of a prohibited access will be `App::abort(403)`. Otherwise the third parameter will be returned. So you can use it like:
 
 ```php
 Entrust::routeNeedsRole( 'admin/advanced*', 'Owner', Redirect::to('/home') );


### PR DESCRIPTION
The 3rd parameter of `Entrust::routeNeedsRole`and `Entrust::routeNeedsPermission` if it's `null` returns an `App::abort(403)` according to the source
