### PR TITLE
Permission assignment/retrieval from Role model

### DIFF
--- a/src/Zizaco/Entrust/EntrustRole.php
+++ b/src/Zizaco/Entrust/EntrustRole.php
@@ -48,13 +48,15 @@ class EntrustRole extends Ardent
         parent::boot();
 
         static::saved(function($role){
-            if ($this->_permissionsChanged) {
+            if ($role->_permissionsChanged) {
                 $role->perms()->sync($role->_permissions);
+                $role->_permissionsChanged = false;
             }
         });
         static::updating(function($role){
-            if ($this->_permissionsChanged) {
+            if ($role->_permissionsChanged) {
                 $role->perms()->sync($role->_permissions);
+                $role->_permissionsChanged = false;
             }
         });
     }


### PR DESCRIPTION
In accordance to ticket #53 this pull request contains changes in Role model that slightly improve process of assigning/retrieving permissions.

Unfortunately, this commit could break applications that are still using `roles` table to store permissions since I got rid of old implementations of `getPermissionsAttribute` and `setPermissionsAttribute`.
