### PR TITLE
Add ability to attach multiple roles and permissions at once

### DIFF
--- a/src/Zizaco/Entrust/EntrustRole.php
+++ b/src/Zizaco/Entrust/EntrustRole.php
@@ -132,4 +132,34 @@ class EntrustRole extends Ardent
         $this->perms()->detach( $permission );
     }
 
+    /**
+     * Attach multiple permissions to current role
+     *
+     * @param $permissions
+     * @access public
+     * @return void
+     */
+    public function attachPermissions($permissions)
+    {
+        foreach ($permissions as $permission)
+        {
+            $this->attachPermission($permission);
+        }
+    }
+
+    /**
+     * Detach multiple permissions from current role
+     *
+     * @param $permissions
+     * @access public
+     * @return void
+     */
+    public function detachPermissions($permissions)
+    {
+        foreach ($permissions as $permission)
+        {
+            $this->detachPermission($permission);
+        }
+    }
+
 }

--- a/src/Zizaco/Entrust/HasRole.php
+++ b/src/Zizaco/Entrust/HasRole.php
@@ -175,4 +175,34 @@ trait HasRole
 
         $this->roles()->detach( $role );
     }
+
+    /**
+     * Attach multiple roles to a user
+     *
+     * @param $roles
+     * @access public
+     * @return void
+     */
+    public function attachRoles($roles)
+    {
+        foreach ($roles as $role)
+        {
+            $this->attachRole($role);
+        }
+    }
+
+    /**
+     * Detach multiple roles from a user
+     *
+     * @param $roles
+     * @access public
+     * @return void
+     */
+    public function detachRoles($roles)
+    {
+        foreach ($roles as $role)
+        {
+            $this->detachRole($role);
+        }
+    }
 }


### PR DESCRIPTION
This is a simple addition to the `EntrustPermission` class and the `HasRole` trait.  It gives the ability to add multiple permissions or roles at the same time using a familiar syntax.  They could be used as so:

``` php
// Adding multiple permissions to a role
$baller->addPermissions([$ball_all_day, $ball_all_night]);

// Adding multiple roles to the user
$user->addRoles([$baller, $shotcaller]);
```
