### PR TITLE
Added roles method to get roles associated with a permission.

### DIFF
--- a/src/Zizaco/Entrust/EntrustPermission.php
+++ b/src/Zizaco/Entrust/EntrustPermission.php
@@ -23,6 +23,14 @@ class EntrustPermission extends Ardent
     );
 
     /**
+     * Many-to-Many relations with Roles
+     */
+    public function roles()
+    {
+        return $this->belongsToMany('Role', 'permission_role');
+    }
+
+    /**
      * Before delete all constrained foreign relations
      *
      * @param bool $forced


### PR DESCRIPTION
I added a `roles()` method to allow the ability to find all roles associated with a particular permission.  This could allow someone to make getting all users that have a particular permission much easier than using the query builder to join all the tables together.
