### PR TITLE
Added config file to allow customization of class names and tables.

### DIFF
--- a/src/Zizaco/Entrust/EntrustPermission.php
+++ b/src/Zizaco/Entrust/EntrustPermission.php
@@ -1,16 +1,16 @@
 <?php namespace Zizaco\Entrust;
 
 use LaravelBook\Ardent\Ardent;
+use Config;
 
 class EntrustPermission extends Ardent
 {
-
     /**
      * The database table used by the model.
      *
      * @var string
      */
-    protected $table = 'permissions';
+    protected $table;
 
     /**
      * Ardent validation rules
@@ -23,11 +23,20 @@ class EntrustPermission extends Ardent
     );
 
     /**
+     * Creates a new instance of the model
+     */
+    public function __construct(array $attributes = array()) {
+
+        parent::__construct($attributes);
+        $this->table = Config::get('entrust::permissions_table');
+    }
+
+    /**
      * Many-to-Many relations with Roles
      */
     public function roles()
     {
-        return $this->belongsToMany('Role', 'permission_role');
+        return $this->belongsToMany(Config::get('entrust::role'), 'permission_role');
     }
 
     /**

--- a/src/Zizaco/Entrust/EntrustRole.php
+++ b/src/Zizaco/Entrust/EntrustRole.php
@@ -1,6 +1,7 @@
 <?php namespace Zizaco\Entrust;
 
 use LaravelBook\Ardent\Ardent;
+use Config;
 
 class EntrustRole extends Ardent
 {
@@ -10,7 +11,7 @@ class EntrustRole extends Ardent
      *
      * @var string
      */
-    protected $table = 'roles';
+    protected $table;
 
     /**
      * Ardent validation rules
@@ -22,11 +23,20 @@ class EntrustRole extends Ardent
     );
 
     /**
+     * Creates a new instance of the model
+     */
+    public function __construct(array $attributes = array())
+    {
+        parent::__construct($attributes);
+        $this->table = Config::get('entrust::roles_table');
+    }
+
+    /**
      * Many-to-Many relations with Users
      */
     public function users()
     {
-        return $this->belongsToMany('User', 'assigned_roles');
+        return $this->belongsToMany(Config::get('auth.model'), 'assigned_roles');
     }
 
     /**
@@ -38,7 +48,7 @@ class EntrustRole extends Ardent
         // To maintain backwards compatibility we'll catch the exception if the Permission table doesn't exist.
         // TODO remove in a future version
         try {
-            return $this->belongsToMany('Permission');
+            return $this->belongsToMany(Config::get('entrust::permission'));
         } catch(Execption $e) {}
     }
 

--- a/src/Zizaco/Entrust/HasRole.php
+++ b/src/Zizaco/Entrust/HasRole.php
@@ -1,6 +1,7 @@
 <?php namespace Zizaco\Entrust;
 
 use Symfony\Component\Process\Exception\InvalidArgumentException;
+use Config;
 
 trait HasRole
 {
@@ -9,7 +10,7 @@ trait HasRole
      */
     public function roles()
     {
-        return $this->belongsToMany('Role', 'assigned_roles');
+        return $this->belongsToMany(Config::get('entrust::role'), 'assigned_roles');
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,0 +1,47 @@
+<?php
+
+return array(
+
+    /*
+	|--------------------------------------------------------------------------
+	| Entrust Role Model
+	|--------------------------------------------------------------------------
+	|
+	| This is the Role model used by Entrust to create correct relations.  Update
+    | the role if it is in a different namespace.
+	|
+	*/
+    'role' => '\Role',
+
+    /*
+	|--------------------------------------------------------------------------
+	| Entrust Roles Table
+	|--------------------------------------------------------------------------
+	|
+	| This is the Roles table used by Entrust to save roles to the database.
+	|
+	*/
+    'roles_table' => 'roles',
+
+    /*
+	|--------------------------------------------------------------------------
+	| Entrust Permission Model
+	|--------------------------------------------------------------------------
+	|
+	| This is the Permission model used by Entrust to create correct relations.  Update
+    | the permission if it is in a different namespace.
+	|
+	*/
+    'permission' => '\Permission',
+
+    /*
+	|--------------------------------------------------------------------------
+	| Entrust Permissions Table
+	|--------------------------------------------------------------------------
+	|
+	| This is the Permissions table used by Entrust to save permissions to the database.
+	|
+	*/
+    'permissions_table' => 'permissions',
+
+);


### PR DESCRIPTION
I have seen a couple posts for people requesting to be able to customize table names and change the default models used.  I added a config file that allows you to do just that.  It "ships" with some handy defaults.  It will allow a developer to also namespace their models.  Just change the model that should be used as the permission and role model and the config will keep the models updated.

Note: The user model used by Entrust is updated using the `auth.php` config file.
