### PR TITLE
Remove Ardent's workaround, Ardent updated. [hasSessionStore error resolved]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,10 @@
             "homepage": "http://www.andrewelkins.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/Zizaco/ardent.git"
-        }
-    ],
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "4.x",
-        "laravelbook/ardent": "dev-has-session-fix"
+        "laravelbook/ardent": "dev-master"
     },
     "require-dev": {
         "illuminate/database": "4.x",


### PR DESCRIPTION
Per https://github.com/laravelbook/ardent/pull/154 Ardent updated and stable. No need for workaround. Should resolve #91 and #94. See Also comments on https://github.com/Zizaco/entrust/commit/d030af26975630912d1e1f4bf9da6e6838eb00f9
