### PR TITLE
Fixed configurable Role-Permission pivot table

### DIFF
--- a/src/Zizaco/Entrust/EntrustRole.php
+++ b/src/Zizaco/Entrust/EntrustRole.php
@@ -48,7 +48,7 @@ class EntrustRole extends Ardent
         // To maintain backwards compatibility we'll catch the exception if the Permission table doesn't exist.
         // TODO remove in a future version
         try {
-            return $this->belongsToMany(Config::get('entrust::permission'));
+			return $this->belongsToMany(Config::get('entrust::permission'), Config::get('entrust::permission_role_table'));
         } catch(Execption $e) {}
     }
 


### PR DESCRIPTION
There is an error when Entrust wants to check if a user have a specific permission in a case when the pivot table which connects roles and permissions is not standard. Instead of the table in the configuration standard table name is used.
I fixed this problem in this commit.
