### PR TITLE
Quick fix Blade templating issue in Laravel 4.2

### DIFF
--- a/src/views/generators/migration.blade.php
+++ b/src/views/generators/migration.blade.php
@@ -1,4 +1,4 @@
-{{ '<?php' }}
+<?php echo "<?php\n"; ?>
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;


### PR DESCRIPTION
Addresses issue #138

As of Laravel 4.2 the curly braces (at least in this generator) are not rendering correctly - they should up in the generated file. Until the issue is resolved in the Laravel source, using a simple PHP echo serves as a temporary solution.
