### PR TITLE
Migration bugfix

### DIFF
--- a/src/views/generators/migration.blade.php
+++ b/src/views/generators/migration.blade.php
@@ -26,7 +26,8 @@ class EntrustSetupTables extends Migration {
             $table->increments('id')->unsigned();
             $table->integer('user_id')->unsigned();
             $table->integer('role_id')->unsigned();
-            $table->foreign('user_id')->references('id')->on('{{ Config::get('auth.table') }}');
+            $table->foreign('user_id')->references('id')->on('{{ Config::get('auth.table') }}')
+                ->onUpdate('cascade')->onDelete('cascade');
             $table->foreign('role_id')->references('id')->on('roles');
         });
 


### PR DESCRIPTION
When creating the migrations the library assumes a "users" table. Do not assume, instead put the value that is in the configurations. Also added onUpdate() and onDelete() cascading to user FK.
