### PR TITLE
Change assigned_roles table to user_roles

### DIFF
--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -42,8 +42,8 @@ class MigrationCommand extends Command {
         $roles_table = lcfirst($this->option('table'));
 
         $this->line('');
-        $this->info( "Tables: $roles_table, assigned_roles, permissions, permission_role" );
-        $message = "An migration that creates '$roles_table', 'assigned_roles', 'permissions', 'permission_role'".
+        $this->info( "Tables: $roles_table, user_roles, permissions, permission_role" );
+        $message = "An migration that creates '$roles_table', 'user_roles', 'permissions', 'permission_role'".
         " tables will be created in app/database/migrations directory";
 
         $this->comment( $message );


### PR DESCRIPTION
I was having rather a difficult time figuring out where the pivot table was located in a much larger project where the previous developer had used Entrust for Roles/Permission management. I think the table name change would make it easier to figure that out , without having to browse the code a lot.
