### PR TITLE
Updated Testing Dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "mockery/mockery": "~0.8",
-        "illuminate/database": "~4.0",
-        "league/factory-muffin": "~1.5"
+        "mockery/mockery": "~0.9",
+        "illuminate/database": "~4.0"
     },
     "repositories": [
         {


### PR DESCRIPTION
I was about to upgrade the test suite to factory muffin 2.0, but then I realised you're not actually using factory muffin your tests. If you're interested in what we've been doing, I'm working on an upgrading guide that ~~will probably end up in the made codebase later today: https://github.com/GrahamCampbell/factory-muffin/blob/upgrading/UPGRADING.md~~ has been merged into the main codebase: https://github.com/thephpleague/factory-muffin/blob/master/UPGRADING.md. If you do have a flick through, it would make sense to read the 1.4.x to 1.5.x and 1.5.x to 1.6.x before reading 1.6.x to 2.0.x otherwise some of those class names will be surprise to you.
