### PR TITLE
Forced user_id and role_id for roles relationship

### DIFF
--- a/src/Entrust/HasRole.php
+++ b/src/Entrust/HasRole.php
@@ -12,7 +12,7 @@ trait HasRole
      */
     public function roles()
     {
-        return $this->belongsToMany(Config::get('entrust::role'), Config::get('entrust::assigned_roles_table'));
+        return $this->belongsToMany(Config::get('entrust::role'), Config::get('entrust::assigned_roles_table'), 'user_id', 'role_id');
     }
 
     /**


### PR DESCRIPTION
I choose to not make my own Role and Permission model and just use your EntrustRole and EntrustPermission directly instead.

The issue here is that eloquent will infer the column names from the class name hence trying to set attached_roles.entrust_role_id

By enforcing the column names we get around this issue without any considerable downsides in my opinion.
