### PR TITLE
Migration fixes

### DIFF
--- a/src/Entrust/Entrust.php
+++ b/src/Entrust/Entrust.php
@@ -27,14 +27,14 @@ class Entrust
     /**
      * Checks if the current user has a Role by its name
      *
-     * @param string $name Role name.
+     * @param string $role Role name.
      *
      * @return bool
      */
-    public function hasRole($permission)
+    public function hasRole($role)
     {
         if ($user = $this->user()) {
-            return $user->hasRole($permission);
+            return $user->hasRole($role);
         }
 
         return false;

--- a/src/Entrust/EntrustRole.php
+++ b/src/Entrust/EntrustRole.php
@@ -41,7 +41,7 @@ class EntrustRole extends Ardent
      */
     public function users()
     {
-        return $this->belongsToMany(Config::get('auth.model'), Config::get('entrust::assigned_roles_table'));
+        return $this->belongsToMany(Config::get('auth.model'), Config::get('entrust::user_role_table'));
     }
 
     /**
@@ -94,7 +94,7 @@ class EntrustRole extends Ardent
     public function beforeDelete($forced = false)
     {
         try {
-            DB::table(Config::get('entrust::assigned_roles_table'))->where('role_id', $this->id)->delete();
+            DB::table(Config::get('entrust::user_role_table'))->where('role_id', $this->id)->delete();
             DB::table(Config::get('entrust::permission_role_table'))->where('role_id', $this->id)->delete();
         } catch (Exception $e) {
             // do nothing

--- a/src/Entrust/HasRole.php
+++ b/src/Entrust/HasRole.php
@@ -12,7 +12,7 @@ trait HasRole
      */
     public function roles()
     {
-        return $this->belongsToMany(Config::get('entrust::role'), Config::get('entrust::assigned_roles_table'), 'user_id', 'role_id');
+        return $this->belongsToMany(Config::get('entrust::role'), Config::get('entrust::user_role_table'), 'user_id', 'role_id');
     }
 
     /**

--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -1,6 +1,7 @@
 <?php namespace Zizaco\Entrust;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -18,7 +19,7 @@ class MigrationCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Creates a migration following the Entrust especifications.';
+    protected $description = 'Creates a migration following the Entrust specifications.';
 
     /**
      * Execute the console command.
@@ -28,15 +29,27 @@ class MigrationCommand extends Command
     public function fire()
     {
         $this->laravel->view->addNamespace('entrust',substr(__DIR__,0,-8).'views');
-
-        $roles_table = lcfirst($this->option('table'));
-
+        
+        $roles_table = Config::get('entrust::roles_table');
+        $user_role_table = Config::get('entrust::user_role_table');
+        $permissions_table = Config::get('entrust::permissions_table');
+        $permission_role_table = Config::get('entrust::permission_role_table');
+/*
+        $roles_table = lcfirst($this->option('roles_table'));
+        $user_role_table = lcfirst($this->option('user_role_table'));
+        $permissions_table = lcfirst($this->option('permissions_table'));
+        $permission_role_table = lcfirst($this->option('permission_role_table'));
+*/
         $this->line('');
-        $this->info( "Tables: $roles_table, user_roles, permissions, permission_role" );
-        $message = "A migration that creates '$roles_table', 'user_roles', 'permissions', 'permission_role'".
-        " tables will be created in app/database/migrations directory";
+        $this->info(
+            "Tables: "
+            . "$roles_table, $user_role_table, $permissions_table, $permission_role_table"
+        );
+        $message = "A migration that creates '$roles_table', '$user_role_table', "
+            . "'$permissions_table', '$permission_role_table'"
+            . " tables will be created in the app/database/migrations directory.";
 
-        $this->comment( $message );
+        $this->comment($message);
         $this->line('');
 
         if ( $this->confirm("Proceed with the migration creation? [Yes|no]") ) {
@@ -44,12 +57,19 @@ class MigrationCommand extends Command
             $this->line('');
 
             $this->info( "Creating migration..." );
-            if ( $this->createMigration( $roles_table ) ) {
-
+            
+            $isMigrationCreated = $this->createMigration(
+                $roles_table,
+                $user_role_table,
+                $permissions_table,
+                $permission_role_table
+            );
+            
+            if ($isMigrationCreated) {
                 $this->info( "Migration successfully created!" );
             } else {
                 $this->error(
-                    "Coudn't create migration.\n Check the write permissions".
+                    "Couldn't create migration.\n Check the write permissions".
                     " within the app/database/migrations directory."
                 );
             }
@@ -64,13 +84,40 @@ class MigrationCommand extends Command
      *
      * @return array
      */
-    protected function getOptions()
+/*    protected function getOptions()
     {
         return array(
-            array('table', null, InputOption::VALUE_OPTIONAL, 'Roles table.', 'roles'),
+            array(
+                'roles_table',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Roles table.',
+                Config::get('entrust::roles_table')
+            ),
+            array(
+                'user_role_table',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Table relating users and roles.',
+                Config::get('entrust::user_role_table')
+            ),
+            array(
+                'permissions_table',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Permissions table.',
+                Config::get('entrust::permissions_table')
+            ),
+            array(
+                'permission_role_table',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Table relating permissions and roles.',
+                Config::get('entrust::permission_role_table')
+            ),
         );
     }
-
+*/
     /**
      * Create the migration.
      *
@@ -78,10 +125,19 @@ class MigrationCommand extends Command
      *
      * @return bool
      */
-    protected function createMigration($roles_table = 'roles')
-    {
+    protected function createMigration(
+        $roles_table,
+        $user_role_table,
+        $permissions_table,
+        $permission_role_table
+    ) {
         $migration_file = $this->laravel->path."/database/migrations/".date('Y_m_d_His')."_entrust_setup_tables.php";
-        $output = $this->laravel->view->make('entrust::generators.migration')->with('table', $roles_table)->render();
+        $output = $this->laravel->view->make('entrust::generators.migration')
+            ->with('roles_table', $roles_table)
+            ->with('user_role_table', $user_role_table)
+            ->with('permissions_table', $permissions_table)
+            ->with('permission_role_table', $permission_role_table)
+            ->render();
 
         if (!file_exists($migration_file) && $fs = fopen($migration_file, 'x')) {
             fwrite($fs, $output);

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -2,66 +2,66 @@
 
 return array(
 
-	/*
-	|--------------------------------------------------------------------------
-	| Entrust Role Model
-	|--------------------------------------------------------------------------
-	|
-	| This is the Role model used by Entrust to create correct relations.  Update
-	| the role if it is in a different namespace.
-	|
-	*/
-	'role' => '\Role',
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust Role Model
+    |--------------------------------------------------------------------------
+    |
+    | This is the Role model used by Entrust to create correct relations.  Update
+    | the role if it is in a different namespace.
+    |
+    */
+    'role' => '\Role',
 
-	/*
-	|--------------------------------------------------------------------------
-	| Entrust Roles Table
-	|--------------------------------------------------------------------------
-	|
-	| This is the Roles table used by Entrust to save roles to the database.
-	|
-	*/
-	'roles_table' => 'roles',
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust Roles Table
+    |--------------------------------------------------------------------------
+    |
+    | This is the Roles table used by Entrust to save roles to the database.
+    |
+    */
+    'roles_table' => 'roles',
 
-	/*
-	|--------------------------------------------------------------------------
-	| Entrust Permission Model
-	|--------------------------------------------------------------------------
-	|
-	| This is the Permission model used by Entrust to create correct relations.  Update
-	| the permission if it is in a different namespace.
-	|
-	*/
-	'permission' => '\Permission',
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust Permission Model
+    |--------------------------------------------------------------------------
+    |
+    | This is the Permission model used by Entrust to create correct relations.  Update
+    | the permission if it is in a different namespace.
+    |
+    */
+    'permission' => '\Permission',
 
-	/*
-	|--------------------------------------------------------------------------
-	| Entrust Permissions Table
-	|--------------------------------------------------------------------------
-	|
-	| This is the Permissions table used by Entrust to save permissions to the database.
-	|
-	*/
-	'permissions_table' => 'permissions',
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust Permissions Table
+    |--------------------------------------------------------------------------
+    |
+    | This is the Permissions table used by Entrust to save permissions to the database.
+    |
+    */
+    'permissions_table' => 'permissions',
 
-	/*
-	|--------------------------------------------------------------------------
-	| Entrust permission_role Table
-	|--------------------------------------------------------------------------
-	|
-	| This is the permission_role table used by Entrust to save relationship between permissions and roles to the database.
-	|
-	*/
-	'permission_role_table' => 'permission_role',
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust permission_role Table
+    |--------------------------------------------------------------------------
+    |
+    | This is the permission_role table used by Entrust to save relationship between permissions and roles to the database.
+    |
+    */
+    'permission_role_table' => 'permission_role',
 
-	/*
-	|--------------------------------------------------------------------------
-	| Entrust assigned_roles Table
-	|--------------------------------------------------------------------------
-	|
-	| This is the assigned_roles table used by Entrust to save assigned roles to the database.
-	|
-	*/
-	'assigned_roles_table' => 'assigned_roles',
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust user_role Table
+    |--------------------------------------------------------------------------
+    |
+    | This is the user_role table used by Entrust to save assigned roles to the database.
+    |
+    */
+    'user_role_table' => 'user_role',
 
 );

--- a/src/views/generators/migration.blade.php
+++ b/src/views/generators/migration.blade.php
@@ -1,4 +1,13 @@
-<?php echo "<?php\n"; ?>
+<?php
+use Illuminate\Support\Facades\Config;
+
+$user_table = Config::get('auth.table');
+$user_model = Config::get('auth.model');
+$user_id = (new $user_model())->getKeyName();
+
+echo "<?php\n";
+
+?>
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
@@ -13,24 +22,24 @@ class EntrustSetupTables extends Migration
     public function up()
     {
         // Creates the roles table
-        Schema::create('roles', function ($table) {
+        Schema::create('{{ $roles_table }}', function ($table) {
             $table->increments('id')->unsigned();
             $table->string('name')->unique();
             $table->timestamps();
         });
 
         // Creates the assigned_roles (Many-to-Many relation) table
-        Schema::create('assigned_roles', function ($table) {
+        Schema::create('{{ $user_role_table }}', function ($table) {
             $table->increments('id')->unsigned();
             $table->integer('user_id')->unsigned();
             $table->integer('role_id')->unsigned();
-            $table->foreign('user_id')->references('id')->on('{{ \Illuminate\Support\Facades\Config::get('auth.table') }}')
+            $table->foreign('user_id')->references('{{ $user_id }}')->on('{{ $user_table }}')
                 ->onUpdate('cascade')->onDelete('cascade');
-            $table->foreign('role_id')->references('id')->on('roles');
+            $table->foreign('role_id')->references('id')->on('{{ $roles_table }}');
         });
 
         // Creates the permissions table
-        Schema::create('permissions', function ($table) {
+        Schema::create('{{ $permissions_table }}', function ($table) {
             $table->increments('id')->unsigned();
             $table->string('name')->unique();
             $table->string('display_name');
@@ -38,12 +47,12 @@ class EntrustSetupTables extends Migration
         });
 
         // Creates the permission_role (Many-to-Many relation) table
-        Schema::create('permission_role', function ($table) {
+        Schema::create('{{ $permission_role_table }}', function ($table) {
             $table->increments('id')->unsigned();
             $table->integer('permission_id')->unsigned();
             $table->integer('role_id')->unsigned();
-            $table->foreign('permission_id')->references('id')->on('permissions'); // assumes a users table
-            $table->foreign('role_id')->references('id')->on('roles');
+            $table->foreign('permission_id')->references('id')->on('{{ $permissions_table }}'); // assumes a users table
+            $table->foreign('role_id')->references('id')->on('{{ $roles_table }}');
         });
     }
 
@@ -54,20 +63,20 @@ class EntrustSetupTables extends Migration
      */
     public function down()
     {
-        Schema::table('assigned_roles', function (Blueprint $table) {
-            $table->dropForeign('assigned_roles_user_id_foreign');
-            $table->dropForeign('assigned_roles_role_id_foreign');
+        Schema::table('{{ $user_role_table }}', function (Blueprint $table) {
+            $table->dropForeign('{{ $user_role_table }}_user_id_foreign');
+            $table->dropForeign('{{ $user_role_table }}_role_id_foreign');
         });
 
-        Schema::table('permission_role', function (Blueprint $table) {
-            $table->dropForeign('permission_role_permission_id_foreign');
-            $table->dropForeign('permission_role_role_id_foreign');
+        Schema::table('{{ $permission_role_table }}', function (Blueprint $table) {
+            $table->dropForeign('{{ $permission_role_table }}_permission_id_foreign');
+            $table->dropForeign('{{ $permission_role_table }}_role_id_foreign');
         });
 
-        Schema::drop('assigned_roles');
-        Schema::drop('permission_role');
-        Schema::drop('roles');
-        Schema::drop('permissions');
+        Schema::drop('{{ $user_role_table }}');
+        Schema::drop('{{ $permission_role_table }}');
+        Schema::drop('{{ $roles_table }}');
+        Schema::drop('{{ $permissions_table }}');
     }
 
 }

--- a/tests/HasRoleTest.php
+++ b/tests/HasRoleTest.php
@@ -38,7 +38,7 @@ class HasRoleTest extends PHPUnit_Framework_TestCase
 
         Config::shouldReceive('get')->once()->with('entrust::role')
             ->andReturn('role_table_name');
-        Config::shouldReceive('get')->once()->with('entrust::assigned_roles_table')
+        Config::shouldReceive('get')->once()->with('entrust::user_role_table')
             ->andReturn('assigned_roles_table_name');
 
         /*


### PR DESCRIPTION
This fixes the migration command and generator to use the settings in config.php.
Changes:
1.) Fixed MigrationCommand.php
and migration.blade.php to use configured
settings.
2.) Changed assigned_roles to user_role in
config.php, EntrustRole.php, HasRole.php.
3.) Fixed variable name in Entrust.php.
4.) Applied detab.

Issue:
 IMHO, we should delete the lines I have commented out in MigrationCommand.php. I have them commented out b/c I'm not sure how to handle the migration command options.

In the current master branch, `entrust:migration` has an option to change the name of the roles table. This raises some issues. Firstly, why single out the roles table for special treatment? Why not include options to change the names of the other tables? Secondly, these options force the user to update config.php so that the values match the option values they passed to `entrust:migration` (this is important since config.php is accessed throughout the package via the Config facade). If this is the case, they may as well just modify config.php in the first place and not pass options to `entrust:migration`.