### PR TITLE
When using an auth.model that is not of "Users" the pivot id is incorrectly assumed as 'user_id'

### DIFF
--- a/src/Zizaco/Entrust/EntrustRole.php
+++ b/src/Zizaco/Entrust/EntrustRole.php
@@ -36,7 +36,7 @@ class EntrustRole extends Ardent
      */
     public function users()
     {
-        return $this->belongsToMany(Config::get('auth.model'), Config::get('entrust::assigned_roles_table'));
+        return $this->belongsToMany(Config::get('auth.model'), Config::get('entrust::assigned_roles_table'),'role_id','user_id');
     }
 
     /**


### PR DESCRIPTION
Added explicit pivots ids for relation users of assigne_roles_table.
