### PR TITLE
Update Entrust.php

### DIFF
--- a/src/Entrust/Entrust.php
+++ b/src/Entrust/Entrust.php
@@ -87,7 +87,7 @@ class Entrust
 
         $filter_name = implode('_',$roles).'_'.substr(md5($route),0,6);
 
-        if (!$result instanceof Closure) {
+        if (!$result instanceof \Closure) {
             $result = function () use ($roles, $result, $cumulative) {
                 $hasARole = array();
                 foreach ($roles as $role) {


### PR DESCRIPTION
`Closure` is in the default namespace.
`$result instanceof Closure` will always return `false` when the namespace is not specified.
