### PR TITLE
Re-order reverse migration scenario to LIFO

### DIFF
--- a/src/views/generators/migration.blade.php
+++ b/src/views/generators/migration.blade.php
@@ -54,20 +54,20 @@ class EntrustSetupTables extends Migration
      */
     public function down()
     {
-        Schema::table('assigned_roles', function (Blueprint $table) {
-            $table->dropForeign('assigned_roles_user_id_foreign');
-            $table->dropForeign('assigned_roles_role_id_foreign');
-        });
-
         Schema::table('permission_role', function (Blueprint $table) {
-            $table->dropForeign('permission_role_permission_id_foreign');
             $table->dropForeign('permission_role_role_id_foreign');
+            $table->dropForeign('permission_role_permission_id_foreign');
         });
 
-        Schema::drop('assigned_roles');
+        Schema::table('assigned_roles', function (Blueprint $table) {
+            $table->dropForeign('assigned_roles_role_id_foreign');
+            $table->dropForeign('assigned_roles_user_id_foreign');
+        });
+
         Schema::drop('permission_role');
-        Schema::drop('roles');
         Schema::drop('permissions');
+        Schema::drop('assigned_roles');
+        Schema::drop('roles');
     }
 
 }


### PR DESCRIPTION
I think it's good to reverse the migration in receding scenario, as reverse mean to last in first out (lifo)