### PR TITLE
Added support for polymorphic roles and multiple scopes...basically Model ACLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,24 @@ class User extends Eloquent /* or ConfideUser 'wink' */{
 This will do the trick to enable the relation with `Role` and the following methods `roles`, `hasRole( $name )`,
 `can( $permission )`, and `ability($roles, $permissions, $options)` within your `User` model.
 
+> This fork of the Entrust package extends the above behavior with the ability to  achieve polymorphic roles and permissions on other Models. You may now add an optional Model class and instance id to the above commands to restrict the scope of the role/permission. For example, `hasRole( $name, $modelName, $modelId )`,
+`can( $permission, $modelName, $modelId )` will check for a role or permission for a specific Model. See the Usage section below for further explaination.
+
+The above discussion of roles and permissions have been restricted to users in the global scope. Often times, it is desirable to apply permissions on a specific resource within your application. This is now possibly by adding the `HasModelRole` trait to a Model. For example, consider the follow example of a Trip: 
+
+```php
+<?php
+
+use Zizaco\Entrust\HasModelRole;
+
+class Trip extends Eloquent {
+    use HasModelRole; // Add this trait to the models you want to protect with roles and permissions
+	
+...  
+```
+
+This will add the following methods `hasRole( $name )`, `can( $permission )`, and `ability($roles, $permissions, $options)` within your `Trip` model. These methods will work identicaly as before, but apply specifically to the model instance thus giving you fine-grain control over which resources you keep private and which you Entrust to others.  
+
 Don't forget to dump composer autoload
 
     $ composer dump-autoload
@@ -141,7 +159,7 @@ $admin->save();
 
 ```
 
-Next, with both roles created let's assign then to the users. Thanks to the `HasRole` trait this is as easy as:
+Next, with these roles created let's assign then to the users. Thanks to the `HasRole` trait this is as easy as:
 
 ```php
 $user = User::where('username','=','Zizaco')->first();
@@ -158,6 +176,11 @@ Now we just need to add permissions to those Roles.
 $managePosts = new Permission;
 $managePosts->name = 'manage_posts';
 $managePosts->display_name = 'Manage Posts';
+$managePosts->save();
+
+$viewPosts = new Permission;
+$viewPosts->name = 'view_posts';
+$viewPosts->display_name = 'View Posts';
 $managePosts->save();
 
 $manageUsers = new Permission;
@@ -180,12 +203,74 @@ $user->can("manage_users"); // false
 
 You can have as many `Role`s as you want for each `User` and vice versa.
 
+While this is fine for many situations, there are times when you don't want to give global permissions to a user to, for example, `manage_posts`. This fork of Entrust allows us to add fine-grained access control on specific Models and Model instances. To see what we mean, let's look at our Trip Model. 
+
+Recently our example users has started to travel a bit. As a result, they are now going to start contributing to travel reviews. Since they are new to the travel review genre, they will collaborate with another author on all their content. Until they have a little experience under their belt, they should not be able to edit any Trip reviews they have not been assigned. This kind of behavior is what this fork of Entrust enables.
+
+Let's create a new role to keep things clean.
+
+```php
+
+$editor = new Role;
+$editor->name = 'Trip Editor';
+$editor->save();
+```
+
+Now we can add the users as follows. 
+
+```php
+$user = User::where('username','=','Zizaco')->first();
+
+/* role attach alias */
+$user->attachRole( $editor, 'Trip', 1 ); // Any model class can be specified. Model id should be an integer value
+
+/* OR the eloquent's original: */
+$user->roles()->attach( $admin->id, array( 'model_name' => 'Trip', 'model_id' => 1 ) ); // id and relation fields
+```
+
+Now we just need to add permissions to the `Trip Editor` Role.
+
+```php
+$manageTrips = new Permission;
+$manageTrips->name = 'manage_trips';
+$manageTrips->display_name = 'Manage Trips';
+$manageTrips->save();
+
+$editor->perms()->sync(array($manageTrips->id));
+```
+
+Now we can check for roles and permissions simply by doing:
+
+```php
+$trip1 = Trip::find(1);
+$trip2 = Trip::find(2);
+
+// check for Role and Permission for authenticated user on a Trip instance
+$trip1->hasRole("Trip Editor"); // true
+$trip2->hasRole("Trip Editor"); // false
+$trip1->can("manage_trips"); // true
+$trip2->can("manage_trips"); // false
+
+// check Role for a specific user
+$user->hasRole("Trip Editor"); // false - role was not given globally
+$user->hasRole("Trip Editor", 'Trips'); // false - role was not given at a Model level
+$user->hasRole("Trip Editor", 'Trips', 1); // true - role was given just for this Model instance
+$user->hasRole("Trip Editor", 'Trips', 2); // false - role was not given for this Model instance
+
+// check Permission for a specific user
+$user->can("manage_trips"); // false - role with this permission was not given globally
+$user->can("manage_trips", 'Trips'); // false - role with this permission was not given at a Model level
+$user->can("manage_trips", 'Trips', 1); // true - role with this permission was given just for this Model instance
+$user->can("manage_trips", 'Trips', 2); // false - role with this permission was not given for this Model instance
+
+```
+
 More advanced checking can be done using the awesome `ability` function. It takes in three parameters (roles, permissions, options).
 `roles` is a set of roles to check. `permissions` is a set of permissions to check.
 Either of the roles or permissions variable can be a comma separated string or array.
 
 ```php
-$user->ability(array('Admin','Owner'), array('manage_posts','manage_users'));
+$user->ability(array('Admin','Owner'), array('manage_posts','manage_users');
 //or
 $user->ability('Admin,Owner', 'manage_posts,manage_users');
 
@@ -198,12 +283,18 @@ The third parameter is an options array.
 ```php
 $options = array(
 'validate_all' => true | false (Default: false),
-'return_type' => boolean | array | both (Default: boolean)
+'return_type' => boolean | array | both (Default: boolean),
+'model_name' => string,
+'model_id' => int
 );
 ```
 `validate_all` is a boolean flag to set whether to check all the values for true, or to return true if at least one role or permission is matched.
 
 `return_type` specifies whether to return a boolean, array of checked values, or both in an array.
+
+`model_name` is the name of the Model class to which you wish to grant a role.
+
+`model_id` is an instance id of a Model object.
 
 Here's some example output.
 
@@ -247,6 +338,15 @@ Entrust::routeNeedsRole( 'admin/advanced*', 'Owner' );
 Entrust::routeNeedsPermission( 'admin/post*', array('manage_posts','manage_comments') );
 
 Entrust::routeNeedsRole( 'admin/advanced*', array('Owner','Writer') );
+
+// Only users with roles that have the 'manage_trips' permission for the 
+// Trip Model will be able to access routes starting with 'admin/trips'.
+Entrust::routeNeedsPermission( 'admin/trips*', 'manage_trips:Trip:{tripId}' );
+
+// Only users with roles that have a global 'Owner' role or the 'Trip Editor' role 
+// for the Trip Model will be able to access routes starting with 'admin/trips'.
+Entrust::routeNeedsRole( 'admin/trips*', array('Owner','Trip Editor:Trip') );
+
 ```
 
 Both of these methods accept a third parameter. If the third parameter is null then the return of a prohibited access will be `App::abort(403)`. Otherwise the third parameter will be returned. So you can use it like:
@@ -275,7 +375,7 @@ Entrust::routeNeedsRoleOrPermission( 'admin/advanced*', array('Owner','Writer'),
 
 Entrust roles/permissions can be used in filters by simply using the `can` and `hasRole` methods from within the Facade.
 
-```php
+```php  
 Route::filter('manage_posts', function()
 {
     if (! Entrust::can('manage_posts') ) // Checks the current user
@@ -287,11 +387,25 @@ Route::filter('manage_posts', function()
 // Only users with roles that have the 'manage_posts' permission will
 // be able to access any admin/post route.
 Route::when('admin/post*', 'manage_posts');
+```  
+
+```php  
+Route::filter('manage_trips', function($tripId)
+{
+    if (! Entrust::can('manage_trips', 'Trip', $tripId) ) // Checks the current user
+    {
+        return Redirect::to('admin');
+    }
+});
+
+// Only users with roles that have the 'manage_trips' permission will
+// be able to access any admin/post route.
+Route::when('admin/trips/{tripId}/*', 'manage_trips');
 ```
 
 Using a filter to check for a role:
 
-```php
+```php  
 Route::filter('owner_role', function()
 {
     if (! Entrust::hasRole('Owner') ) // Checks the current user
@@ -304,7 +418,21 @@ Route::filter('owner_role', function()
 Route::when('admin/advanced*', 'owner_role');
 ```
 
+```php
+Route::filter('trip_editor_role', function($tripId)
+{
+    if (! Entrust::hasRole('Trip Editor', 'Trip', $tripId) ) // Checks the current user
+    {
+        App::abort(404);
+    }
+});
+
+// Only trip editors with permission to a Trip will have access to routes within admin/advanced
+Route::when('admin/trips/{tripId}/*', 'trip_editor_role');
+```
+
 As you can see `Entrust::hasRole()` and `Entrust::can()` checks if the user is logged, and then if he has the role or permission. If the user is not logged the return will also be `false`.
+
 
 ## Troubleshooting
 
@@ -322,23 +450,7 @@ EntrustRole->name has a length limitation set within the rules variable of the [
 
 You can adjust it by changing your Role Model.
 
-```php
-<?php
 
-use Zizaco\Entrust\EntrustRole;
-
-class Role extends EntrustRole
-{
-    /**
-     * Ardent validation rules
-     *
-     * @var array
-     */
-    public static $rules = array(
-      'name' => 'required|between:4,255'
-    );
-}
-```
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,12 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/support": "~4.2"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.9",
-        "illuminate/database": "~4.0",
-        "symfony/process": "~2.3"
+        "orchestra/testbench": "2.2.*"
     },
     "suggest": {
         "zizaco/confide":"Confide is an authentication solution for Laravel 4 that couples very well with Entrust"

--- a/src/Entrust/Entrust.php
+++ b/src/Entrust/Entrust.php
@@ -32,35 +32,47 @@ class Entrust
     }
 
     /**
-     * Checks if the current user has a Role by its name
+     * Checks if a user has a Role by its name. Can optionally specify a class
+     * name and id to check for a role on a given class or class instance
+     * respectively.
      *
      * @param string $name Role name.
+     * @param string $modelName the name of the resource model to which the check for roles and permissions will apply
+     * @param mixed $modelId the instance identifier of the resource model
      *
      * @return bool
      */
-    public function hasRole($permission)
+    public function hasRole($name, $modelName=false, $modelId=false)
     {
-        if ($user = $this->user()) {
-            return $user->hasRole($permission);
+        $user = $this->user();
+
+        if (!empty($user)) {
+            return $user->hasRole($name, $modelName, $modelId);
         }
 
         return false;
     }
 
     /**
-     * Check if the current user has a permission by its name
+     * Check if the current user has a permission by its name. Can optionally
+     * specify a class name and id to check for a role on a given class or
+     * class instance respectively.
      *
      * @param string $permission Permission string.
+     * @param string $modelName the name of the resource model to which the check for roles and permissions will apply
+     * @param mixed $modelId the instance identifier of the resource model
      *
      * @return bool
      */
-    public function can($permission)
+    public function can($permission, $modelName=false, $modelId=false)
     {
-        if ($user = $this->user()) {
-            return $user->can($permission);
-        }
+      $user = $this->user();
 
-        return false;
+      if ($user) {
+          return $user->can($permission, $modelName, $modelId);
+      }
+
+      return false;
     }
 
     /**
@@ -98,7 +110,9 @@ class Entrust
             $result = function () use ($roles, $result, $cumulative) {
                 $hasARole = array();
                 foreach ($roles as $role) {
-                    if ($this->hasRole($role)) {
+                    list($roleName, $modelName, $modelId) = explode(':', $role);
+
+                    if ($this->hasRole($roleName, $modelName, $modelId)) {
                         $hasARole[] = true;
                     } else {
                         $hasARole[] = false;
@@ -151,7 +165,9 @@ class Entrust
             $result = function () use ($permissions, $result, $cumulative) {
                 $hasAPermission = array();
                 foreach ($permissions as $permission) {
-                    if ($this->can($permission)) {
+                    list($permissionName, $modelName, $modelId) = explode(':', $permission);
+
+                    if ($this->can($permissionName, $modelName, $modelId)) {
                         $hasAPermission[] = true;
                     } else {
                         $hasAPermission[] = false;
@@ -208,7 +224,9 @@ class Entrust
             $result = function () use ($roles, $permissions, $result, $cumulative) {
                 $hasARole = array();
                 foreach ($roles as $role) {
-                    if ($this->hasRole($role)) {
+                    list($roleName, $modelName, $modelId) = explode(':', $role);
+
+                    if ($this->hasRole($roleName, $modelName, $modelId)) {
                         $hasARole[] = true;
                     } else {
                         $hasARole[] = false;
@@ -217,7 +235,9 @@ class Entrust
 
                 $hasAPermission = array();
                 foreach ($permissions as $permission) {
-                    if ($this->can($permission)) {
+                    list($permissionName, $modelName, $modelId) = explode(':', $permission);
+
+                    if ($this->can($permissionName, $modelName, $modelId)) {
                         $hasAPermission[] = true;
                     } else {
                         $hasAPermission[] = false;

--- a/src/Entrust/EntrustRole.php
+++ b/src/Entrust/EntrustRole.php
@@ -54,7 +54,7 @@ class EntrustRole extends Ardent
         // To maintain backwards compatibility we'll catch the exception if the Permission table doesn't exist.
         // TODO remove in a future version.
         try {
-			return $this->belongsToMany(Config::get('entrust::permission'), Config::get('entrust::permission_role_table'));
+			      return $this->belongsToMany(Config::get('entrust::permission'), Config::get('entrust::permission_role_table'));
         } catch (Exception $e) {
             // do nothing
         }

--- a/src/Entrust/HasModelRole.php
+++ b/src/Entrust/HasModelRole.php
@@ -1,0 +1,150 @@
+<?php namespace Zizaco\Entrust;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Facade;
+use Symfony\Component\Process\Exception\InvalidArgumentException;
+
+trait HasModelRole
+{
+    /**
+     * Checks if the user has a Role for this resource by its name.
+     *
+     * @param string $name Role name.
+     *
+     * @return bool
+     */
+    public function hasRole($name)
+    {
+        return Facade::getFacadeApplication()->auth->user()->hasRole($name, __CLASS__, $this->id);
+    }
+
+    /**
+     * Check if user has a permission by its name.
+     *
+     * @param string $permission Permission string.
+     *
+     * @return bool
+     */
+    public function can($permission)
+    {
+        return Facade::getFacadeApplication()->auth->user()->can($name, __CLASS__, $this->id);
+    }
+
+    /**
+     * Checks role(s) and permission(s).
+     *
+     * @param string|array $roles       Array of roles or comma separated string
+     * @param string|array $permissions Array of permissions or comma separated string.
+     * @param array        $options     validate_all (true|false) or return_type (boolean|array|both)
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return array|bool
+     */
+    public function ability($roles, $permissions, $options = array())
+    {
+        // Convert string to array if that's what is passed in.
+        if (!is_array($roles)) {
+            $roles = explode(',', $roles);
+        }
+        if (!is_array($permissions)) {
+            $permissions = explode(',', $permissions);
+        }
+
+        // Set up default values and validate options.
+        if (!isset($options['validate_all'])) {
+            $options['validate_all'] = false;
+        } else {
+            if ($options['validate_all'] != true && $options['validate_all'] != false) {
+                throw new InvalidArgumentException();
+            }
+        }
+        if (!isset($options['return_type'])) {
+            $options['return_type'] = 'boolean';
+        } else {
+            if ($options['return_type'] != 'boolean' &&
+                $options['return_type'] != 'array' &&
+                $options['return_type'] != 'both') {
+                throw new InvalidArgumentException();
+            }
+        }
+
+        // Loop through roles and permissions and check each.
+        $checkedRoles = array();
+        $checkedPermissions = array();
+        foreach ($roles as $role) {
+            $checkedRoles[$role] = $this->hasRole($role);
+        }
+        foreach ($permissions as $permission) {
+            $checkedPermissions[$permission] = $this->can($permission);
+        }
+
+        // If validate all and there is a false in either
+        // Check that if validate all, then there should not be any false.
+        // Check that if not validate all, there must be at least one true.
+        if(($options['validate_all'] && !(in_array(false,$checkedRoles) || in_array(false,$checkedPermissions))) ||
+            (!$options['validate_all'] && (in_array(true,$checkedRoles) || in_array(true,$checkedPermissions)))) {
+            $validateAll = true;
+        } else {
+            $validateAll = false;
+        }
+
+        // Return based on option
+        if ($options['return_type'] == 'boolean') {
+            return $validateAll;
+        } elseif ($options['return_type'] == 'array') {
+            return array('roles' => $checkedRoles, 'permissions' => $checkedPermissions);
+        } else {
+            return array($validateAll, array('roles' => $checkedRoles, 'permissions' => $checkedPermissions));
+        }
+
+    }
+
+    /**
+     * Alias to eloquent many-to-many relation's attach() method.
+     *
+     * @param mixed $role
+     *
+     * @return void
+     */
+    public function attachRole($role)
+    {
+        Facade::getFacadeApplication()->auth->user()->attachRole($role, __CLASS__, $this->id);
+    }
+
+    /**
+     * Alias to eloquent many-to-many relation's detach() method.
+     *
+     * @param mixed $role
+     *
+     * @return void
+     */
+    public function detachRole($role)
+    {
+        Facade::getFacadeApplication()->auth->user()->detachRole($role, __CLASS__, $this->id);
+    }
+
+    /**
+     * Attach multiple roles to a user
+     *
+     * @param mixed $roles
+     *
+     * @return void
+     */
+    public function attachRoles($roles)
+    {
+        Facade::getFacadeApplication()->auth->user()->attachRoles($roles, __CLASS__, $this->id);
+    }
+
+    /**
+     * Detach multiple roles from a user
+     *
+     * @param mixed $roles
+     *
+     * @return void
+     */
+    public function detachRoles($roles)
+    {
+        Facade::getFacadeApplication()->auth->user()->detachRoles($roles, __CLASS__, $this->id);
+    }
+}

--- a/src/views/generators/migration.blade.php
+++ b/src/views/generators/migration.blade.php
@@ -24,6 +24,8 @@ class EntrustSetupTables extends Migration
             $table->increments('id')->unsigned();
             $table->integer('user_id')->unsigned();
             $table->integer('role_id')->unsigned();
+            $table->string('model_name');
+            $table->integer('model_id')->unsigned();
             $table->foreign('user_id')->references('id')->on('{{ \Illuminate\Support\Facades\Config::get('auth.table') }}')
                 ->onUpdate('cascade')->onDelete('cascade');
             $table->foreign('role_id')->references('id')->on('roles');
@@ -54,6 +56,7 @@ class EntrustSetupTables extends Migration
      */
     public function down()
     {
+
         Schema::table('assigned_roles', function (Blueprint $table) {
             $table->dropForeign('assigned_roles_user_id_foreign');
             $table->dropForeign('assigned_roles_role_id_foreign');

--- a/tests/EntrustTest.php
+++ b/tests/EntrustTest.php
@@ -21,7 +21,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $app = new stdClass();
         $entrust = m::mock('Zizaco\Entrust\Entrust[user]', [$app]);
         $user = m::mock('_mockedUser');
-    
+
         /*
         |------------------------------------------------------------
         | Expectation
@@ -29,32 +29,56 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         */
         $entrust->shouldReceive('user')
             ->andReturn($user)
-            ->twice()->ordered();
-            
+            ->times(6)->ordered();
+
         $entrust->shouldReceive('user')
             ->andReturn(false)
             ->once()->ordered();
-        
+
         $user->shouldReceive('hasRole')
-            ->with('UserRole')
+            ->with('UserRole', false, false)
             ->andReturn(true)
             ->once();
-            
+
         $user->shouldReceive('hasRole')
-            ->with('NonUserRole')
+            ->with('UserRole', 'SomeResource', false)
+            ->andReturn(true)
+            ->once();
+
+        $user->shouldReceive('hasRole')
+            ->with('UserRole', 'SomeResource', 1)
+            ->andReturn(true)
+            ->once();
+
+        $user->shouldReceive('hasRole')
+            ->with('NonUserRole', false, false)
             ->andReturn(false)
             ->once();
-            
+
+        $user->shouldReceive('hasRole')
+            ->with('NonUserRole', 'SomeResource', false)
+            ->andReturn(false)
+            ->once();
+
+        $user->shouldReceive('hasRole')
+            ->with('NonUserRole', 'SomeResource', 1)
+            ->andReturn(false)
+            ->once();
+
         /*
         |------------------------------------------------------------
         | Assertion
         |------------------------------------------------------------
         */
         $this->assertTrue($entrust->hasRole('UserRole'));
+        $this->assertTrue($entrust->hasRole('UserRole', 'SomeResource'));
+        $this->assertTrue($entrust->hasRole('UserRole', 'SomeResource', 1));
         $this->assertFalse($entrust->hasRole('NonUserRole'));
+        $this->assertFalse($entrust->hasRole('NonUserRole', 'SomeResource'));
+        $this->assertFalse($entrust->hasRole('NonUserRole', 'SomeResource', 1));
         $this->assertFalse($entrust->hasRole('AnyRole'));
     }
-    
+
     public function testCan()
     {
         /*
@@ -65,7 +89,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $app = new stdClass();
         $entrust = m::mock('Zizaco\Entrust\Entrust[user]', [$app]);
         $user = m::mock('_mockedUser');
-    
+
         /*
         |------------------------------------------------------------
         | Expectation
@@ -73,29 +97,53 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         */
         $entrust->shouldReceive('user')
             ->andReturn($user)
-            ->twice()->ordered();
-            
+            ->times(6)->ordered();
+
         $entrust->shouldReceive('user')
             ->andReturn(false)
             ->once()->ordered();
-        
+
         $user->shouldReceive('can')
-            ->with('user_can')
+            ->with('user_can', false, false)
             ->andReturn(true)
             ->once();
-            
+
         $user->shouldReceive('can')
-            ->with('user_cannot')
+            ->with('user_can', 'SomeResource', false)
+            ->andReturn(true)
+            ->once();
+
+        $user->shouldReceive('can')
+            ->with('user_can', 'SomeResource', 1)
+            ->andReturn(true)
+            ->once();
+
+        $user->shouldReceive('can')
+            ->with('user_cannot', false, false)
             ->andReturn(false)
             ->once();
-            
+
+        $user->shouldReceive('can')
+            ->with('user_cannot', 'SomeResource', false)
+            ->andReturn(false)
+            ->once();
+
+        $user->shouldReceive('can')
+            ->with('user_cannot', 'SomeResource', 1)
+            ->andReturn(false)
+            ->once();
+
         /*
         |------------------------------------------------------------
         | Assertion
         |------------------------------------------------------------
         */
         $this->assertTrue($entrust->can('user_can'));
+        $this->assertTrue($entrust->can('user_can', 'SomeResource'));
+        $this->assertTrue($entrust->can('user_can', 'SomeResource', 1));
         $this->assertFalse($entrust->can('user_cannot'));
+        $this->assertFalse($entrust->can('user_cannot', 'SomeResource'));
+        $this->assertFalse($entrust->can('user_cannot', 'SomeResource', 1));
         $this->assertFalse($entrust->can('any_permission'));
     }
 
@@ -110,7 +158,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $app->auth = m::mock('Auth');
         $entrust = new Entrust($app);
         $user = m::mock('_mockedUser');
-    
+
         /*
         |------------------------------------------------------------
         | Expectation
@@ -119,7 +167,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $app->auth->shouldReceive('user')
             ->andReturn($user)
             ->once();
-            
+
         /*
         |------------------------------------------------------------
         | Assertion
@@ -127,7 +175,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         */
         $this->assertSame($user, $entrust->user());
     }
-    
+
     public function testRouteNeedsRole()
     {
         /*
@@ -138,7 +186,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $app = new stdClass();
         $app->router = m::mock('Route');
         $entrust = new Entrust($app);
-        
+
         $route = 'route';
         $oneRole = 'RoleA';
         $manyRole = ['RoleA', 'RoleB', 'RoleC'];
@@ -158,7 +206,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $app->router->shouldReceive('filter')
             ->with(m::anyOf($oneRoleFilterName, $manyRoleFilterName), m::mustBe($emptyClosure))
             ->twice()->ordered();
-            
+
         $app->router->shouldReceive('when')
             ->with($route, m::anyOf($oneRoleFilterName, $manyRoleFilterName))
             ->times(4);
@@ -169,11 +217,11 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         |------------------------------------------------------------
         */
         $entrust->routeNeedsRole($route, $oneRole);
-        $entrust->routeNeedsRole($route, $manyRole);    
+        $entrust->routeNeedsRole($route, $manyRole);
         $entrust->routeNeedsRole($route, $oneRole, $emptyClosure);
-        $entrust->routeNeedsRole($route, $manyRole, $emptyClosure);     
+        $entrust->routeNeedsRole($route, $manyRole, $emptyClosure);
     }
-    
+
     public function testFilterGeneratedByRouteNeedsRole()
     {
         /*
@@ -186,7 +234,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $entrust = m::mock('Zizaco\Entrust\Entrust[hasRole]', [$app]);
         $facadeApp = m::mock('_mockedApplication');
         Facade::setFacadeApplication($facadeApp);
-        
+
         $route = 'route';
         $userRoleA = 'UserRoleA';
         $userRoleB = 'UserRoleB';
@@ -194,7 +242,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $nonUserRoleB = 'NonUserRoleB';
         $nonUserRoles = [$nonUserRoleA, $nonUserRoleB];
         $customResponse = new stdClass();
-        
+
         $roles = [];
         $isPassedCustomResponse = false;
         $isCumulative = false;
@@ -209,7 +257,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
             if (!($filter instanceof Closure)) {
                 return false;
             }
-            
+
             $result = null;
             $numAgainst = count(array_intersect($nonUserRoles, $roles));
             $numTotal = count($roles);
@@ -232,7 +280,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
 
             return true;
         };
-        
+
         $runTestCase = function (
             array $caseRoles,
             $result = null,
@@ -251,9 +299,9 @@ class EntrustTest extends PHPUnit_Framework_TestCase
                 $caseRoles,
                 $result,
                 $cumulative
-            );      
+            );
         };
- 
+
         /*
         |------------------------------------------------------------
         | Expectation
@@ -263,39 +311,39 @@ class EntrustTest extends PHPUnit_Framework_TestCase
             ->with(m::type('string'), m::on($callFilterAndAssert));
         $app->router->shouldReceive('when')
             ->with($route, m::type('string'));
-            
+
         $facadeApp->shouldReceive('abort')
             ->with(403)->andThrow('Exception', 'abort');
 
         $entrust->shouldReceive('hasRole')
-            ->with(m::anyOf($userRoleA, $userRoleB))
+            ->with(m::anyOf($userRoleA, $userRoleB), false, false)
             ->andReturn(true);
         $entrust->shouldReceive('hasRole')
-            ->with(m::anyOf($nonUserRoleA, $nonUserRoleB))
+            ->with(m::anyOf($nonUserRoleA, $nonUserRoleB), false, false)
             ->andReturn(false);
 
         /*
         |------------------------------------------------------------
         | Assertion
         |------------------------------------------------------------
-        */  
+        */
         // Case: User has both roles.
         $runTestCase([$userRoleA, $userRoleB]);
         $runTestCase([$userRoleA, $userRoleB], null, false);
         $runTestCase([$userRoleA, $userRoleB], $customResponse);
         $runTestCase([$userRoleA, $userRoleB], $customResponse, false);
-        
+
         // Case: User lacks a role.
         $runTestCase([$nonUserRoleA, $userRoleB]);
         $runTestCase([$nonUserRoleA, $userRoleB], null, false);
         $runTestCase([$nonUserRoleA, $userRoleB], $customResponse);
         $runTestCase([$nonUserRoleA, $userRoleB], $customResponse, false);
-        
+
         // Case: User lacks both roles.
         $runTestCase([$nonUserRoleA, $nonUserRoleB]);
         $runTestCase([$nonUserRoleA, $nonUserRoleB], null, false);
         $runTestCase([$nonUserRoleA, $nonUserRoleB], $customResponse);
-        $runTestCase([$nonUserRoleA, $nonUserRoleB], $customResponse, false);    
+        $runTestCase([$nonUserRoleA, $nonUserRoleB], $customResponse, false);
     }
 
     public function testRouteNeedsPermission()
@@ -308,7 +356,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $app = new stdClass();
         $app->router = m::mock('Route');
         $entrust = new Entrust($app);
-        
+
         $route = 'route';
         $onePerm = 'can_a';
         $manyPerm = ['can_a', 'can_b', 'can_c'];
@@ -321,14 +369,14 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         |------------------------------------------------------------
         | Expectation
         |------------------------------------------------------------
-        */  
+        */
         $app->router->shouldReceive('filter')
             ->with(m::anyOf($onePermFilterName, $manyPermFilterName), m::type('Closure'))
             ->twice()->ordered();
         $app->router->shouldReceive('filter')
             ->with(m::anyOf($onePermFilterName, $manyPermFilterName), m::mustBe($emptyClosure))
             ->twice()->ordered();
-            
+
         $app->router->shouldReceive('when')
             ->with($route, m::anyOf($onePermFilterName, $manyPermFilterName))
             ->times(4);
@@ -339,11 +387,11 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         |------------------------------------------------------------
         */
         $entrust->routeNeedsPermission($route, $onePerm);
-        $entrust->routeNeedsPermission($route, $manyPerm);  
+        $entrust->routeNeedsPermission($route, $manyPerm);
         $entrust->routeNeedsPermission($route, $onePerm, $emptyClosure);
-        $entrust->routeNeedsPermission($route, $manyPerm, $emptyClosure);       
+        $entrust->routeNeedsPermission($route, $manyPerm, $emptyClosure);
     }
-    
+
     public function testFilterGeneratedByRouteNeedsPermission()
     {
         /*
@@ -356,7 +404,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $entrust = m::mock('Zizaco\Entrust\Entrust[can]', [$app]);
         $facadeApp = m::mock('_mockedApplication');
         Facade::setFacadeApplication($facadeApp);
-        
+
         $route = 'route';
         $userPermA = 'user_can_a';
         $userPermB = 'user_can_b';
@@ -364,7 +412,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $nonUserPermB = 'user_cannot_b';
         $nonUserPerms = [$nonUserPermA, $nonUserPermB];
         $customResponse = new stdClass();
-        
+
         $perms = [];
         $isPassedCustomResponse = false;
         $isCumulative = false;
@@ -379,7 +427,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
             if (!($filter instanceof Closure)) {
                 return false;
             }
-            
+
             $result = null;
             $numAgainst = count(array_intersect($nonUserPerms, $perms));
             $numTotal = count($perms);
@@ -402,7 +450,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
 
             return true;
         };
-        
+
         $runTestCase = function (
             array $casePerms,
             $result = null,
@@ -421,9 +469,9 @@ class EntrustTest extends PHPUnit_Framework_TestCase
                 $casePerms,
                 $result,
                 $cumulative
-            );      
+            );
         };
- 
+
         /*
         |------------------------------------------------------------
         | Expectation
@@ -433,42 +481,42 @@ class EntrustTest extends PHPUnit_Framework_TestCase
             ->with(m::type('string'), m::on($callFilterAndAssert));
         $app->router->shouldReceive('when')
             ->with($route, m::type('string'));
-            
+
         $facadeApp->shouldReceive('abort')
             ->with(403)->andThrow('Exception', 'abort');
 
         $entrust->shouldReceive('can')
-            ->with(m::anyOf($userPermA, $userPermB))
+            ->with(m::anyOf($userPermA, $userPermB), false, false)
             ->andReturn(true);
         $entrust->shouldReceive('can')
-            ->with(m::anyOf($nonUserPermA, $nonUserPermB))
+            ->with(m::anyOf($nonUserPermA, $nonUserPermB), false, false)
             ->andReturn(false);
 
         /*
         |------------------------------------------------------------
         | Assertion
         |------------------------------------------------------------
-        */  
+        */
         // Case: User has both permissions.
         $runTestCase([$userPermA, $userPermB]);
         $runTestCase([$userPermA, $userPermB], null, false);
         $runTestCase([$userPermA, $userPermB], $customResponse);
         $runTestCase([$userPermA, $userPermB], $customResponse, false);
-        
-        
+
+
         // Case: User lacks a permission.
         $runTestCase([$nonUserPermA, $userPermB]);
         $runTestCase([$nonUserPermA, $userPermB], null, false);
         $runTestCase([$nonUserPermA, $userPermB], $customResponse, false);
         $runTestCase([$nonUserPermA, $userPermB], $customResponse);
-        
+
         // Case: User lacks both permissions.
         $runTestCase([$nonUserPermA, $nonUserPermB]);
         $runTestCase([$nonUserPermA, $nonUserPermB], null, false);
         $runTestCase([$nonUserPermA, $nonUserPermB], $customResponse, false);
-        $runTestCase([$nonUserPermA, $nonUserPermB], $customResponse);    
+        $runTestCase([$nonUserPermA, $nonUserPermB], $customResponse);
     }
-    
+
     public function testRouteNeedsRoleOrPermission()
     {
         /*
@@ -479,7 +527,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $app = new stdClass();
         $app->router = m::mock('Route');
         $entrust = new Entrust($app);
-        
+
         $route = 'route';
         $oneRole = 'RoleA';
         $manyRole = ['RoleA', 'RoleB', 'RoleC'];
@@ -496,7 +544,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         |------------------------------------------------------------
         | Expectation
         |------------------------------------------------------------
-        */  
+        */
         $app->router->shouldReceive('filter')
             ->with(
                 m::anyOf(
@@ -504,7 +552,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
                     $oneRoleManyPermFilterName,
                     $manyRoleOnePermFilterName,
                     $manyRoleManyPermFilterName
-                ), 
+                ),
                 m::type('Closure')
             )
             ->times(4)->ordered();
@@ -515,18 +563,18 @@ class EntrustTest extends PHPUnit_Framework_TestCase
                     $oneRoleManyPermFilterName,
                     $manyRoleOnePermFilterName,
                     $manyRoleManyPermFilterName
-                ), 
+                ),
                 m::mustBe($emptyClosure)
             )
             ->times(4)->ordered();
 
         $app->router->shouldReceive('when')
             ->with(
-                $route, 
+                $route,
                 m::anyOf(
-                    $oneRoleOnePermFilterName, 
-                    $oneRoleManyPermFilterName, 
-                    $manyRoleOnePermFilterName, 
+                    $oneRoleOnePermFilterName,
+                    $oneRoleManyPermFilterName,
+                    $manyRoleOnePermFilterName,
                     $manyRoleManyPermFilterName
                 )
             )
@@ -545,9 +593,9 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $entrust->routeNeedsRoleOrPermission($route, $oneRole, $onePerm, $emptyClosure);
         $entrust->routeNeedsRoleOrPermission($route, $oneRole, $manyPerm, $emptyClosure);
         $entrust->routeNeedsRoleOrPermission($route, $manyRole, $onePerm, $emptyClosure);
-        $entrust->routeNeedsRoleOrPermission($route, $manyRole, $manyPerm, $emptyClosure);      
+        $entrust->routeNeedsRoleOrPermission($route, $manyRole, $manyPerm, $emptyClosure);
     }
-    
+
     public function testFilterGeneratedByRouteNeedsRoleOrPermission()
     {
         /*
@@ -572,7 +620,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
         $nonUserPermB = 'user_cannot_b';
         $nonUserRolesPerms = [$nonUserRoleA, $nonUserRoleB, $nonUserPermA, $nonUserPermB];
         $customResponse = new stdClass();
-        
+
         $roles = [];
         $perms = [];
         $isPassedCustomResponse = false;
@@ -612,7 +660,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
 
             return true;
         };
-        
+
         $runTestCase = function (
             array $caseRoles,
             array $casePerms,
@@ -634,7 +682,7 @@ class EntrustTest extends PHPUnit_Framework_TestCase
                 $casePerms,
                 $result,
                 $cumulative
-            );      
+            );
         };
 
         /*
@@ -646,52 +694,52 @@ class EntrustTest extends PHPUnit_Framework_TestCase
             ->with(m::type('string'), m::on($callFilterAndAssert));
         $app->router->shouldReceive('when')
             ->with($route, m::type('string'));
-            
+
         $facadeApp->shouldReceive('abort')
             ->with(403)->andThrow('Exception', 'abort');
-            
+
         $entrust->shouldReceive('hasRole')
-            ->with(m::anyOf($userRoleA, $userRoleB))
+            ->with(m::anyOf($userRoleA, $userRoleB), false, false)
             ->andReturn(true);
         $entrust->shouldReceive('hasRole')
-            ->with(m::anyOf($nonUserRoleA, $nonUserRoleB))
+            ->with(m::anyOf($nonUserRoleA, $nonUserRoleB), false, false)
             ->andReturn(false);
         $entrust->shouldReceive('can')
-            ->with(m::anyOf($userPermA, $userPermB))
+            ->with(m::anyOf($userPermA, $userPermB), false, false)
             ->andReturn(true);
         $entrust->shouldReceive('can')
-            ->with(m::anyOf($nonUserPermA, $nonUserPermB))
+            ->with(m::anyOf($nonUserPermA, $nonUserPermB), false, false)
             ->andReturn(false);
 
         /*
         |------------------------------------------------------------
         | Assertion
         |------------------------------------------------------------
-        */  
+        */
         // Case: User has everything.
         $runTestCase([$userRoleA, $userRoleB], [$userPermA, $userPermB]);
         $runTestCase([$userRoleA, $userRoleB], [$userPermA, $userPermB], null, true);
         $runTestCase([$userRoleA, $userRoleB], [$userPermA, $userPermB], $customResponse, true);
         $runTestCase([$userRoleA, $userRoleB], [$userPermA, $userPermB], $customResponse);
-        
+
         // Case: User lacks a role.
         $runTestCase([$nonUserRoleA, $userRoleB], [$userPermA, $userPermB]);
         $runTestCase([$nonUserRoleA, $userRoleB], [$userPermA, $userPermB], null, true);
         $runTestCase([$nonUserRoleA, $userRoleB], [$userPermA, $userPermB], $customResponse, true);
         $runTestCase([$nonUserRoleA, $userRoleB], [$userPermA, $userPermB], $customResponse);
-        
+
         // Case: User lacks a permission.
         $runTestCase([$userRoleA, $userRoleB], [$nonUserPermA, $userPermB]);
         $runTestCase([$userRoleA, $userRoleB], [$nonUserPermA, $userPermB], null, true);
         $runTestCase([$userRoleA, $userRoleB], [$nonUserPermA, $userPermB], $customResponse, true);
         $runTestCase([$userRoleA, $userRoleB], [$nonUserPermA, $userPermB], $customResponse);
-        
+
         // Case: User lacks a role and a permission.
         $runTestCase([$nonUserRoleA, $userRoleB], [$nonUserPermA, $userPermB]);
         $runTestCase([$nonUserRoleA, $userRoleB], [$nonUserPermA, $userPermB], null, true);
         $runTestCase([$nonUserRoleA, $userRoleB], [$nonUserPermA, $userPermB], $customResponse, true);
         $runTestCase([$nonUserRoleA, $userRoleB], [$nonUserPermA, $userPermB], $customResponse);
-        
+
         // Case: User lacks everything.
         $runTestCase([$nonUserRoleA, $nonUserRoleB], [$nonUserPermA, $nonUserPermB]);
         $runTestCase([$nonUserRoleA, $nonUserRoleB], [$nonUserPermA, $nonUserPermB], null, true);
@@ -705,6 +753,6 @@ class EntrustTest extends PHPUnit_Framework_TestCase
             return implode('_', $roles) . '_' . substr(md5($route), 0, 6);
         } else {
             return implode('_', $roles) . '_' . implode('_', $permissions) . '_' . substr(md5($route), 0, 6);
-        }   
+        }
     }
 }


### PR DESCRIPTION
Added support for polymorphic roles and multiple scopes by extending the pivot table with additional fields and adding support for specifying a Model class and Model object id when calling addRole. All other relevant calls have been updated to support optional $modelName and $modelId fields such that you can now apply a role or permission to any model object.

Added new HasModelRole trait to the package to allow for easy role and permission checking of the current user on any Model.
Added unit tests to validate the behavior of the new features.