### PR TITLE
Updated readme with user model fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ Next, use the `EntrustUserTrait` trait in your existing `User` model. For exampl
 ```php
 <?php
 
+use Zizaco\Entrust\EntrustRole;
 use Zizaco\Entrust\Traits\EntrustUserTrait;
 
-class User extends Eloquent
+class User extends EntrustRole
 {
     use EntrustUserTrait; // add this trait to your user model
 


### PR DESCRIPTION
Trying to set up the user roles gave me fatal errors about missing the attachRole() function, so I'm now extending the user model with the EntrustRole class instead of Laravel's default class to fix this..

I didn't have a deeper look into the code, so I don't know whether it makes sense or not. 