### PR TITLE
Update array syntax

### DIFF
--- a/src/Entrust/Contracts/EntrustUserInterface.php
+++ b/src/Entrust/Contracts/EntrustUserInterface.php
@@ -48,7 +48,7 @@ interface EntrustUserInterface
      *
      * @return array|bool
      */
-    public function ability($roles, $permissions, $options = array());
+    public function ability($roles, $permissions, $options = []);
     
     /**
      * Alias to eloquent many-to-many relation's attach() method.

--- a/src/Entrust/EntrustPermission.php
+++ b/src/Entrust/EntrustPermission.php
@@ -29,7 +29,7 @@ class EntrustPermission extends Model implements EntrustPermissionInterface
      *
      * @param array $attributes
      */
-    public function __construct(array $attributes = array())
+    public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
         $this->table = Config::get('entrust.permissions_table');

--- a/src/Entrust/EntrustRole.php
+++ b/src/Entrust/EntrustRole.php
@@ -29,7 +29,7 @@ class EntrustRole extends Model implements EntrustRoleInterface
      *
      * @param array $attributes
      */
-    public function __construct(array $attributes = array())
+    public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
         $this->table = Config::get('entrust.roles_table');

--- a/src/Entrust/EntrustServiceProvider.php
+++ b/src/Entrust/EntrustServiceProvider.php
@@ -92,8 +92,8 @@ class EntrustServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return array(
+        return [
             'command.entrust.migration'
-        );
+        ];
     }
 }

--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -129,7 +129,7 @@ trait EntrustUserTrait
      *
      * @return array|bool
      */
-    public function ability($roles, $permissions, $options = array())
+    public function ability($roles, $permissions, $options = [])
     {
         // Convert string to array if that's what is passed in.
         if (!is_array($roles)) {
@@ -158,8 +158,8 @@ trait EntrustUserTrait
         }
 
         // Loop through roles and permissions and check each.
-        $checkedRoles = array();
-        $checkedPermissions = array();
+        $checkedRoles = [];
+        $checkedPermissions = [];
         foreach ($roles as $role) {
             $checkedRoles[$role] = $this->hasRole($role);
         }
@@ -181,9 +181,9 @@ trait EntrustUserTrait
         if ($options['return_type'] == 'boolean') {
             return $validateAll;
         } elseif ($options['return_type'] == 'array') {
-            return array('roles' => $checkedRoles, 'permissions' => $checkedPermissions);
+            return ['roles' => $checkedRoles, 'permissions' => $checkedPermissions];
         } else {
-            return array($validateAll, array('roles' => $checkedRoles, 'permissions' => $checkedPermissions));
+            return [$validateAll, ['roles' => $checkedRoles, 'permissions' => $checkedPermissions]];
         }
 
     }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -8,7 +8,7 @@
  * @package Zizaco\Entrust
  */
 
-return array(
+return [
 
     /*
     |--------------------------------------------------------------------------
@@ -75,4 +75,4 @@ return array(
     */
     'role_user_table' => 'role_user',
 
-);
+];

--- a/tests/EntrustTest.php
+++ b/tests/EntrustTest.php
@@ -320,14 +320,14 @@ class EntrustTest extends PHPUnit_Framework_TestCase
 
     public function simpleFilterDataProvider()
     {
-        return array(
+        return [
             // Filter passes, null is returned
-            array(true, 'nullFilterTest'),
+            [true, 'nullFilterTest'],
             // Filter fails, App::abort() is called
-            array(false, 'abortFilterTest', true),
+            [false, 'abortFilterTest', true],
             // Filter fails, custom response is returned
-            array(false, 'customResponseFilterTest', false, new stdClass())
-        );
+            [false, 'customResponseFilterTest', false, new stdClass()]
+        ];
     }
 
     /**
@@ -373,24 +373,24 @@ class EntrustTest extends PHPUnit_Framework_TestCase
 
     public function routeNeedsRoleOrPermissionFilterDataProvider()
     {
-        return array(
+        return [
             // Both role and permission pass, null is returned
-            array(true,  true,  'nullFilterTest'),
-            array(true,  true,  'nullFilterTest', true),
+            [true,  true,  'nullFilterTest'],
+            [true,  true,  'nullFilterTest', true],
             // Role OR permission fail, require all is false, null is returned
-            array(false, true,  'nullFilterTest'),
-            array(true,  false, 'nullFilterTest'),
+            [false, true,  'nullFilterTest'],
+            [true,  false, 'nullFilterTest'],
             // Role and/or permission fail, App::abort() is called
-            array(false, true,  'abortFilterTest', true,  true),
-            array(true,  false, 'abortFilterTest', true,  true),
-            array(false, false, 'abortFilterTest', false, true),
-            array(false, false, 'abortFilterTest', true,  true),
+            [false, true,  'abortFilterTest', true,  true],
+            [true,  false, 'abortFilterTest', true,  true],
+            [false, false, 'abortFilterTest', false, true],
+            [false, false, 'abortFilterTest', true,  true],
             // Role and/or permission fail, custom response is returned
-            array(false, true,  'customResponseFilterTest', true,  false, new stdClass()),
-            array(true,  false, 'customResponseFilterTest', true,  false, new stdClass()),
-            array(false, false, 'customResponseFilterTest', false, false, new stdClass()),
-            array(false, false, 'customResponseFilterTest', true,  false, new stdClass())
-        );
+            [false, true,  'customResponseFilterTest', true,  false, new stdClass()],
+            [true,  false, 'customResponseFilterTest', true,  false, new stdClass()],
+            [false, false, 'customResponseFilterTest', false, false, new stdClass()],
+            [false, false, 'customResponseFilterTest', true,  false, new stdClass()]
+        ];
     }
 
     /**


### PR DESCRIPTION
Laravel 5 already requires PHP >=5.4, so we can use bracket syntax without hesitation. By the way it's already used in some places in this package.