### PR TITLE
Add artisan command to create models

### DIFF
--- a/src/Entrust/EntrustServiceProvider.php
+++ b/src/Entrust/EntrustServiceProvider.php
@@ -33,6 +33,7 @@ class EntrustServiceProvider extends ServiceProvider
 
         // Register commands
         $this->commands('command.entrust.migration');
+        $this->commands('command.entrust.classes');
     }
 
     /**
@@ -71,6 +72,9 @@ class EntrustServiceProvider extends ServiceProvider
         $this->app->bindShared('command.entrust.migration', function ($app) {
             return new MigrationCommand();
         });
+        $this->app->bindShared('command.entrust.classes', function ($app) {
+            return new ClassCreatorCommand();
+        });
     }
 
     /**
@@ -93,7 +97,8 @@ class EntrustServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'command.entrust.migration'
+            'command.entrust.migration',
+            'command.entrust.classes'
         ];
     }
 }

--- a/src/commands/ClassCreatorCommand.php
+++ b/src/commands/ClassCreatorCommand.php
@@ -1,0 +1,109 @@
+<?php namespace Zizaco\Entrust;
+
+/**
+ * This file is part of Entrust,
+ * a role & permission management solution for Laravel.
+ *
+ * @license MIT
+ * @package Zizaco\Entrust
+ */
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
+
+class ClassCreatorCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'entrust:classes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates Role and Permission classes';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $this->laravel->view->addNamespace('entrust', substr(__DIR__, 0, -8).'views');
+
+        $roleModel           = Config::get('entrust.role');
+        $permissionModel     = Config::get('entrust.permission');
+
+        $roleModelName       = explode('/', $roleModel);
+        $roleModelName       = end($roleModelName);
+
+        $permissionModelName = explode('/', $permissionModel);
+        $permissionModelName = end($permissionModelName);
+
+        $classes = compact('roleModelName', 'permissionModelName');
+
+        $this->line('');
+        $this->info( "Models: $roleModelName, $permissionModelName" );
+
+        $message = "Creates '$roleModelName', '$permissionModelName' classes will be created in app directory";
+
+        $this->comment($message);
+        $this->line('');
+
+        if ($this->confirm("Proceed with the class creation? [Yes|no]", "Yes")) {
+
+            $this->line('');
+            $this->info("Creating classes...");
+
+            foreach ($classes as $key => $class) {
+
+                $classFile = app_path($class . '.php');
+
+                if (file_exists($classFile)
+                    && !$this->confirm($class . " exists. Proceed with overwriting? [Yes|no]", "Yes")) {
+                    $this->info($class . " class creation skipped.");
+                    continue;
+                }
+
+                if ($this->createClass($class, $classFile)) {
+                    $this->info($class . " class successfully created!");
+                } else {
+                    $this->error(
+                        "Couldn't create " . $class . " class.\n".
+                        "Check the write permissions within the app directory."
+                    );
+                }
+            }
+
+        }
+
+        $this->line('');
+    }
+
+    /**
+     * Create the migration.
+     *
+     * @param string $class Class name
+     * @param string $classFile Path to class file
+     *
+     * @return bool
+     */
+    protected function createClass($class, $classFile)
+    {
+        $data = compact('class');
+        $output = $this->laravel->view->make('entrust::generators.class')->with($data)->render();
+
+        if ($fs = fopen($classFile, 'w')) {
+            fwrite($fs, $output);
+            fclose($fs);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/views/generators/class.blade.php
+++ b/src/views/generators/class.blade.php
@@ -1,0 +1,7 @@
+<?php echo '<?php' ?> namespace App;
+
+use Zizaco\Entrust\Entrust<?php echo $class ?>;
+
+class <?php echo $class ?> extends Entrust<?php echo $class ?>
+{
+}


### PR DESCRIPTION
Created Artisan command `php artisan entrust:classes` that generates all requires classes (Role, Permission).

Copying classes from readme is a bit weird, so let's have a convenient way to automatically generate them.