### PR TITLE
allow a closure for the result parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,11 @@ So you can use it like:
 
 ```php
 Entrust::routeNeedsRole('admin/advanced*', 'owner', Redirect::to('/home'));
+
+// You may use a closure for the result parameter which will only be executed when access is denied.
+Entrust::routeNeedsRole('admin/advanced*', 'owner', function () {
+    Redirect::to('/home')->withErrors('Access Denied');
+});
 ```
 
 Furthermore both of these methods accept a fourth parameter.

--- a/src/Entrust/Entrust.php
+++ b/src/Entrust/Entrust.php
@@ -93,6 +93,10 @@ class Entrust
             $hasRole = $this->hasRole($roles, $requireAll);
 
             if (!$hasRole) {
+                // if result is a closure, then call it and use the returned value
+                if (!empty($result) && !is_string($result) && is_callable($result)) {
+                    $result = $result();
+                }
                 return empty($result) ? $this->app->abort(403) : $result;
             }
         };
@@ -127,6 +131,10 @@ class Entrust
             $hasPerm = $this->can($permissions, $requireAll);
 
             if (!$hasPerm) {
+                // if result is a closure, then call it and use the returned value
+                if (!empty($result) && !is_string($result) && is_callable($result)) {
+                    $result = $result();
+                }
                 return empty($result) ? $this->app->abort(403) : $result;
             }
         };
@@ -170,6 +178,10 @@ class Entrust
             }
 
             if (!$hasRolePerm) {
+                // if result is a closure, then call it and use the returned value
+                if (!empty($result) && !is_string($result) && is_callable($result)) {
+                    $result = $result();
+                }
                 return empty($result) ? $this->app->abort(403) : $result;
             }
         };


### PR DESCRIPTION
Allow a closure for the result parameter in routeNeedsRole(), routeNeedsPermission(), and routeNeedsRoleOrPermission()

The closure will only be executed when the user does not have the required privileges.
This can be used to flash an error message or trigger some other action when access is denied.