### PR TITLE
Reflect renaming of SoftDeletingTrait to SoftDeletes

### DIFF
--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -35,7 +35,7 @@ trait EntrustUserTrait
         parent::boot();
 
         static::deleting(function($user) {
-            if (!method_exists(Config::get('auth.model'), 'bootSoftDeletingTrait')) {
+            if (!method_exists(Config::get('auth.model'), 'bootSoftDeletes')) {
                 $user->roles()->sync([]);
             }
 


### PR DESCRIPTION
The roles were deleted because EntrustUserTrait was looking for the old name of the SoftDeletingTrait that was changed to SoftDeletes.