### PR TITLE
Implement middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ contains the latest entrust version for Laravel 4.
     - [Concepts](#concepts)
         - [Checking for Roles & Permissions](#checking-for-roles--permissions)
         - [User ability](#user-ability)
+    - [Middleware](#middleware)
     - [Short syntax route filter](#short-syntax-route-filter)
     - [Route filter](#route-filter)
 - [Troubleshooting](#troubleshooting)
@@ -36,21 +37,29 @@ contains the latest entrust version for Laravel 4.
 
 ## Installation
 
-In order to install Laravel 5 Entrust, just add 
+In order to install Laravel 5 Entrust, just add
 
     "zizaco/entrust": "dev-laravel-5"
 
 to your composer.json. Then run `composer install` or `composer update`.
 
-Then in your `config/app.php` add 
+Then in your `config/app.php` add
 ```php
     'Zizaco\Entrust\EntrustServiceProvider'
-```    
+```
 in the `providers` array and
 ```php
     'Entrust' => 'Zizaco\Entrust\EntrustFacade'
 ```
 to the `aliases` array.
+
+If you are going to use [Middleware](#middleware) you also need to add
+```php
+    'role' => 'Zizaco\Entrust\Middleware\EntrustRole',
+    'permission' => 'Zizaco\Entrust\Middleware\EntrustPermission',
+    'ability' => 'Zizaco\Entrust\Middleware\EntrustAbility',
+```
+to `routeMiddleware` array in `app/Http/Kernel.php`.
 
 ## Configuration
 
@@ -325,6 +334,31 @@ var_dump($allValidations);
 // }
 ```
 
+### Middleware
+
+You can use a middleware to filter routes and route groups by permission or role
+```php
+Route::group(['prefix' => 'admin', 'middleware' => ['role:admin']], function() {
+    Route::get('/', 'AdminController@welcome');
+    Route::get('/manage', ['middleware' => ['permission:manage-admins'], 'uses' => 'AdminController@manageAdmins']);
+});
+```
+
+It is possible to use pipe symbol as *OR* operator:
+```php
+'middleware' => ['role:admin|root']
+```
+
+To emulate *AND* functionality just use multiple instances of middleware
+```php
+'middleware' => ['permission:owner', 'permission:writer']
+```
+
+For more complex situations use `ability` middleware which accepts 3 parameters: roles, permissions, validate_all
+```php
+'middleware' => ['ability:admin|owner,create-post|edit-user,true']
+```
+
 ### Short syntax route filter
 
 To filter a route by permission or role you can call the following in your `app/Http/routes.php`:
@@ -425,7 +459,7 @@ When trying to use the EntrustUserTrait methods, you encounter the error which l
 
     Class name must be a valid object or a string
 
-then probably you don't have published Entrust assets or something went wrong when you did it. 
+then probably you don't have published Entrust assets or something went wrong when you did it.
 First of all check that you have the `entrust.php` file in your `app/config` directory.
 If you don't, then try `php artisan vendor:publish` and, if it does not appear, manually copy the `/vendor/zizaco/entrust/src/config/config.php` file in your config directory and rename it `entrust.php`.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ in the `providers` array and
 ```
 to the `aliases` array.
 
-If you are going to use [Middleware](#middleware) you also need to add
+If you are going to use [Middleware](#middleware) (requires Laravel 5.1 or later) you also need to add
 ```php
     'role' => 'Zizaco\Entrust\Middleware\EntrustRole',
     'permission' => 'Zizaco\Entrust\Middleware\EntrustPermission',

--- a/src/Entrust/Middleware/EntrustAbility.php
+++ b/src/Entrust/Middleware/EntrustAbility.php
@@ -1,4 +1,4 @@
-<?php namespace Zizaco\Entrust;
+<?php namespace Zizaco\Entrust\Middleware;
 
 /**
  * This file is part of Entrust,
@@ -8,16 +8,20 @@
  * @package Zizaco\Entrust
  */
 
+use Closure;
+
  class EntrustAbility
  {
-    /**
-     * Handle an incoming request.
-     *
-     * @param  \Illuminate\Http\Request $request
-     * @param  \Closure $next
-     * @param null $roles
-     * @return mixed
-     */
+	 /**
+	  * Handle an incoming request.
+	  *
+	  * @param \Illuminate\Http\Request $request
+	  * @param Closure $next
+	  * @param $roles
+	  * @param $permissions
+	  * @param bool $validateAll
+	  * @return mixed
+	  */
     public function handle($request, Closure $next, $roles, $permissions, $validateAll = false)
     {
         if (! $request->user()->ability(explode('|', $roles), explode('|', $permissions), array('validate_all' => $validateAll))) {

--- a/src/Entrust/Middleware/EntrustAbility.php
+++ b/src/Entrust/Middleware/EntrustAbility.php
@@ -10,24 +10,24 @@
 
 use Closure;
 
- class EntrustAbility
- {
-	 /**
-	  * Handle an incoming request.
-	  *
-	  * @param \Illuminate\Http\Request $request
-	  * @param Closure $next
-	  * @param $roles
-	  * @param $permissions
-	  * @param bool $validateAll
-	  * @return mixed
-	  */
-    public function handle($request, Closure $next, $roles, $permissions, $validateAll = false)
-    {
-        if (! $request->user()->ability(explode('|', $roles), explode('|', $permissions), array('validate_all' => $validateAll))) {
-            abort(403);
-        }
+class EntrustAbility
+{
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @param \Illuminate\Http\Request $request
+	 * @param Closure $next
+	 * @param $roles
+	 * @param $permissions
+	 * @param bool $validateAll
+	 * @return mixed
+	 */
+	public function handle($request, Closure $next, $roles, $permissions, $validateAll = false)
+	{
+		if (! $request->user()->ability(explode('|', $roles), explode('|', $permissions), array('validate_all' => $validateAll))) {
+			abort(403);
+		}
 
-        return $next($request);
-    }
+		return $next($request);
+	}
 }

--- a/src/Entrust/Middleware/EntrustAbility.php
+++ b/src/Entrust/Middleware/EntrustAbility.php
@@ -1,0 +1,29 @@
+<?php namespace Zizaco\Entrust;
+
+/**
+ * This file is part of Entrust,
+ * a role & permission management solution for Laravel.
+ *
+ * @license MIT
+ * @package Zizaco\Entrust
+ */
+
+ class EntrustAbility
+ {
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @param null $roles
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $roles, $permissions, $validateAll = false)
+    {
+        if (! $request->user()->ability(explode('|', $roles), explode('|', $permissions), array('validate_all' => $validateAll))) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Entrust/Middleware/EntrustAbility.php
+++ b/src/Entrust/Middleware/EntrustAbility.php
@@ -9,9 +9,22 @@
  */
 
 use Closure;
+use Illuminate\Contracts\Auth\Guard;
 
 class EntrustAbility
 {
+	protected $auth;
+
+	/**
+	 * Creates a new instance of the middleware.
+	 *
+	 * @param Guard $auth
+	 */
+	public function __construct(Guard $auth)
+	{
+		$this->auth = $auth;
+	}
+
 	/**
 	 * Handle an incoming request.
 	 *
@@ -24,7 +37,7 @@ class EntrustAbility
 	 */
 	public function handle($request, Closure $next, $roles, $permissions, $validateAll = false)
 	{
-		if (! $request->user()->ability(explode('|', $roles), explode('|', $permissions), array('validate_all' => $validateAll))) {
+		if ($this->auth->guest() || !$request->user()->ability(explode('|', $roles), explode('|', $permissions), array('validate_all' => $validateAll))) {
 			abort(403);
 		}
 

--- a/src/Entrust/Middleware/EntrustPermission.php
+++ b/src/Entrust/Middleware/EntrustPermission.php
@@ -1,4 +1,4 @@
-<?php namespace Zizaco\Entrust;
+<?php namespace Zizaco\Entrust\Middleware;
 
 /**
  * This file is part of Entrust,
@@ -8,14 +8,16 @@
  * @package Zizaco\Entrust
  */
 
+use Closure;
+
  class EntrustPermission
  {
     /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request $request
-     * @param  \Closure $next
-     * @param $permissions
+     * @param  Closure $next
+     * @param  $permissions
      * @return mixed
      */
     public function handle($request, Closure $next, $permissions)

--- a/src/Entrust/Middleware/EntrustPermission.php
+++ b/src/Entrust/Middleware/EntrustPermission.php
@@ -10,22 +10,22 @@
 
 use Closure;
 
- class EntrustPermission
- {
-    /**
-     * Handle an incoming request.
-     *
-     * @param  \Illuminate\Http\Request $request
-     * @param  Closure $next
-     * @param  $permissions
-     * @return mixed
-     */
-    public function handle($request, Closure $next, $permissions)
-    {
-        if (! $request->user()->can(explode('|', $permissions))) {
-            abort(403);
-        }
+class EntrustPermission
+{
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @param  \Illuminate\Http\Request $request
+	 * @param  Closure $next
+	 * @param  $permissions
+	 * @return mixed
+	 */
+	public function handle($request, Closure $next, $permissions)
+	{
+		if (! $request->user()->can(explode('|', $permissions))) {\
+			abort(403);
+		}
 
-        return $next($request);
-    }
+		return $next($request);
+	}
 }

--- a/src/Entrust/Middleware/EntrustPermission.php
+++ b/src/Entrust/Middleware/EntrustPermission.php
@@ -35,7 +35,7 @@ class EntrustPermission
 	 */
 	public function handle($request, Closure $next, $permissions)
 	{
-		if ($this->auth->guest() || !$request->user()->can(explode('|', $permissions))) {\
+		if ($this->auth->guest() || !$request->user()->can(explode('|', $permissions))) {
 			abort(403);
 		}
 

--- a/src/Entrust/Middleware/EntrustPermission.php
+++ b/src/Entrust/Middleware/EntrustPermission.php
@@ -1,0 +1,29 @@
+<?php namespace Zizaco\Entrust;
+
+/**
+ * This file is part of Entrust,
+ * a role & permission management solution for Laravel.
+ *
+ * @license MIT
+ * @package Zizaco\Entrust
+ */
+
+ class EntrustPermission
+ {
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @param $permissions
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $permissions)
+    {
+        if (! $request->user()->can(explode('|', $permissions))) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Entrust/Middleware/EntrustPermission.php
+++ b/src/Entrust/Middleware/EntrustPermission.php
@@ -9,9 +9,22 @@
  */
 
 use Closure;
+use Illuminate\Contracts\Auth\Guard;
 
 class EntrustPermission
 {
+	protected $auth;
+
+	/**
+	 * Creates a new instance of the middleware.
+	 *
+	 * @param Guard $auth
+	 */
+	public function __construct(Guard $auth)
+	{
+		$this->auth = $auth;
+	}
+
 	/**
 	 * Handle an incoming request.
 	 *
@@ -22,7 +35,7 @@ class EntrustPermission
 	 */
 	public function handle($request, Closure $next, $permissions)
 	{
-		if (! $request->user()->can(explode('|', $permissions))) {\
+		if ($this->auth->guest() || !$request->user()->can(explode('|', $permissions))) {\
 			abort(403);
 		}
 

--- a/src/Entrust/Middleware/EntrustRole.php
+++ b/src/Entrust/Middleware/EntrustRole.php
@@ -10,22 +10,22 @@
 
 use Closure;
 
- class EntrustRole
- {
-    /**
-     * Handle an incoming request.
-     *
-     * @param  \Illuminate\Http\Request $request
-     * @param  Closure $next
-     * @param  $roles
-     * @return mixed
-     */
-    public function handle($request, Closure $next, $roles)
-    {
-        if (! $request->user()->hasRole(explode('|', $roles))) {
-            abort(403);
-        }
+class EntrustRole
+{
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @param  \Illuminate\Http\Request $request
+	 * @param  Closure $next
+	 * @param  $roles
+	 * @return mixed
+	 */
+	public function handle($request, Closure $next, $roles)
+	{
+		if (! $request->user()->hasRole(explode('|', $roles))) {
+			abort(403);
+		}
 
-        return $next($request);
-    }
+		return $next($request);
+	}
 }

--- a/src/Entrust/Middleware/EntrustRole.php
+++ b/src/Entrust/Middleware/EntrustRole.php
@@ -1,0 +1,29 @@
+<?php namespace Zizaco\Entrust;
+
+/**
+ * This file is part of Entrust,
+ * a role & permission management solution for Laravel.
+ *
+ * @license MIT
+ * @package Zizaco\Entrust
+ */
+
+ class EntrustRole
+ {
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @param null $roles
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $roles)
+    {
+        if (! $request->user()->hasRole(explode('|', $roles))) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Entrust/Middleware/EntrustRole.php
+++ b/src/Entrust/Middleware/EntrustRole.php
@@ -1,4 +1,4 @@
-<?php namespace Zizaco\Entrust;
+<?php namespace Zizaco\Entrust\Middleware;
 
 /**
  * This file is part of Entrust,
@@ -8,14 +8,16 @@
  * @package Zizaco\Entrust
  */
 
+use Closure;
+
  class EntrustRole
  {
     /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request $request
-     * @param  \Closure $next
-     * @param null $roles
+     * @param  Closure $next
+     * @param  $roles
      * @return mixed
      */
     public function handle($request, Closure $next, $roles)

--- a/src/Entrust/Middleware/EntrustRole.php
+++ b/src/Entrust/Middleware/EntrustRole.php
@@ -9,9 +9,22 @@
  */
 
 use Closure;
+use Illuminate\Contracts\Auth\Guard;
 
 class EntrustRole
 {
+	protected $auth;
+
+	/**
+	 * Creates a new instance of the middleware.
+	 *
+	 * @param Guard $auth
+	 */
+	public function __construct(Guard $auth)
+	{
+		$this->auth = $auth;
+	}
+
 	/**
 	 * Handle an incoming request.
 	 *
@@ -22,7 +35,7 @@ class EntrustRole
 	 */
 	public function handle($request, Closure $next, $roles)
 	{
-		if (! $request->user()->hasRole(explode('|', $roles))) {
+		if ($this->auth->guest() || !$request->user()->hasRole(explode('|', $roles))) {
 			abort(403);
 		}
 


### PR DESCRIPTION
Implemented middleware. Closes #316

We probably still need to inject and use `App::abort(403)` instead of `abort(403)` helper function. Also this feature still needs tests and I don't have experience writing them.

Functionality can be further enhanced by allowing user to return custom responses in case of failed authorization. One way is to add additional parameter to middleware as redirect URL but that will require to hardcode redirect response in middleware since middleware parameters are strings. Probably there are more flexible solutions.