### PR TITLE
Placeholder Support to Permission Check (update of #234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,17 @@ Auth::user()->hasRole('role-name');
 Auth::user()->can('permission-name);
 ```
 
+You can also use placeholders (wildcards) to check any matching permission by doing:
+
+```php
+// match any admin permission
+$user->can("admin.*"); // true
+
+// match any permission about users
+$user->can("*_users"); // true
+```
+
+
 #### User ability
 
 More advanced checking can be done using the awesome `ability` function.

--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -108,7 +108,7 @@ trait EntrustUserTrait
             foreach ($this->roles as $role) {
                 // Validate against the Permission table
                 foreach ($role->perms as $perm) {
-                    if ($perm->name == $permission) {
+                    if (str_is( $permission, $perm->name) ) {
                         return true;
                     }
                 }

--- a/tests/EntrustUserTest.php
+++ b/tests/EntrustUserTest.php
@@ -116,6 +116,40 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($user->can(['manage_d', 'manage_e']));
     }
 
+
+    public function testCanWithPlaceholderSupport ()
+    {
+        /*
+        |------------------------------------------------------------
+        | Set
+        |------------------------------------------------------------
+        */
+        $permA = $this->mockPermission('admin.posts');
+        $permB = $this->mockPermission('admin.pages');
+        $permC = $this->mockPermission('admin.users');
+
+        $role = $this->mockRole('Role');
+
+        $role->perms = [$permA, $permB, $permC];
+
+        $user = new HasRoleUser();
+        $user->roles = [$role];
+
+        /*
+        |------------------------------------------------------------
+        | Assertion
+        |------------------------------------------------------------
+        */
+        $this->assertTrue($user->can('admin.posts'));
+        $this->assertTrue($user->can('admin.pages'));
+        $this->assertTrue($user->can('admin.users'));
+        $this->assertFalse($user->can('admin.config'));
+
+        $this->assertTrue($user->can(['admin.*']));
+        $this->assertFalse($user->can(['site.*']));
+    }
+    
+    
     public function testAbilityShouldReturnBoolean()
     {
         /*


### PR DESCRIPTION
initial credit goes to @hkan for https://github.com/Zizaco/entrust/pull/234

I have updated the initial pull request with tests as well so hopefully this can be pulled in? @Zizaco 

"This is be useful for the people that namespace their permissions like me. With this PR, it will be possible to check permissions like $user->can('posts.*') to see if user has any permission under the posts namespace."