### PR TITLE
Blade support

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,15 +362,19 @@ Three directives are available for use within your Blade templates. What you giv
 
 ```php
 @role('admin')
-    <p>This is visible to users with the admin role. Gets translated to \Entrust::role('admin')</p>
+    <p>This is visible to users with the admin role. Gets translated to 
+    \Entrust::role('admin')</p>
 @endrole
 
 @permission('manage-admins')
-    <p>This is visible to users with the given permissions. Gets translated to \Entrust::can('manage-admins'). The @can directive is already taken by core laravel authorization package, hence the @permission directive instead.</p>
+    <p>This is visible to users with the given permissions. Gets translated to 
+    \Entrust::can('manage-admins'). The @can directive is already taken by core 
+    laravel authorization package, hence the @permission directive instead.</p>
 @endpermission
 
 @ability('admin,owner', 'create-post,edit-user')
-    <p>This is visible to users with the given abilities. Gets translated to \Entrust::ability('admin,owner', 'create-post,edit-user')</p>
+    <p>This is visible to users with the given abilities. Gets translated to 
+    \Entrust::ability('admin,owner', 'create-post,edit-user')</p>
 @endability
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ contains the latest entrust version for Laravel 4.
     - [Concepts](#concepts)
         - [Checking for Roles & Permissions](#checking-for-roles--permissions)
         - [User ability](#user-ability)
+    - [Blade templates](#blade-templates)
     - [Middleware](#middleware)
     - [Short syntax route filter](#short-syntax-route-filter)
     - [Route filter](#route-filter)
@@ -353,6 +354,24 @@ Entrust::ability('admin,owner', 'create-post,edit-user');
 // is identical to
 
 Auth::user()->ability('admin,owner', 'create-post,edit-user');
+```
+
+### Blade templates
+
+Three directives are available for use within your Blade templates. What you give as the directive arguments will be directly passed to the corresponding `Entrust` function.
+
+```php
+@role('admin')
+    <p>This is visible to users with the admin role. Gets translated to \Entrust::role('admin')</p>
+@endrole
+
+@permission('manage-admins')
+    <p>This is visible to users with the given permissions. Gets translated to \Entrust::can('manage-admins'). The @can directive is already taken by core laravel authorization package, hence the @permission directive instead.</p>
+@endpermission
+
+@ability('admin,owner', 'create-post,edit-user')
+    <p>This is visible to users with the given abilities. Gets translated to \Entrust::ability('admin,owner', 'create-post,edit-user')</p>
+@endability
 ```
 
 ### Middleware

--- a/src/Entrust/EntrustServiceProvider.php
+++ b/src/Entrust/EntrustServiceProvider.php
@@ -33,6 +33,9 @@ class EntrustServiceProvider extends ServiceProvider
 
         // Register commands
         $this->commands('command.entrust.migration');
+        
+        // Register blade directives
+        $this->bladeDirectives();
     }
 
     /**
@@ -47,6 +50,41 @@ class EntrustServiceProvider extends ServiceProvider
         $this->registerCommands();
 
         $this->mergeConfig();
+    }
+
+    /**
+     * Register the blade directives
+     *
+     * @return void
+     */
+    private function bladeDirectives()
+    {
+        // Call to Entrust::hasRole
+        Blade::directive('role', function($expression) {
+            return "<?php if (\\Entrust::hasRole{$expression}) : ?>";
+        });
+
+        Blade::directive('endrole', function($expression) {
+            return "<?php endif; // Entrust::hasRole ?>";
+        });
+
+        // Call to Entrust::can
+        Blade::directive('permission', function($expression) {
+            return "<?php if (\\Entrust::can{$expression}) : ?>";
+        });
+
+        Blade::directive('endpermission', function($expression) {
+            return "<?php endif; // Entrust::can ?>";
+        });
+
+        // Call to Entrust::ability
+        Blade::directive('ability', function($expression) {
+            return "<?php if (\\Entrust::ability{$expression}) : ?>";
+        });
+
+        Blade::directive('endability', function($expression) {
+            return "<?php endif; // Entrust::ability ?>";
+        });
     }
 
     /**


### PR DESCRIPTION
With this new feature, 3 directives are available for use within your Blade templates. What you give as the directive arguments will be directly passed to the corresponding `Entrust` function.

```php
@role('admin')
    <p>This is visible to users with the admin role. Gets translated to 
    \Entrust::role('admin')</p>
@endrole

@permission('manage-admins')
    <p>This is visible to users with the given permissions. Gets translated to 
    \Entrust::can('manage-admins'). The @can directive is already taken by core 
    laravel authorization package, hence the @permission directive instead.</p>
@endpermission

@ability('admin,owner', 'create-post,edit-user')
    <p>This is visible to users with the given abilities. Gets translated to 
    \Entrust::ability('admin,owner', 'create-post,edit-user')</p>
@endability
```