### PR TITLE
Fix namespace

### DIFF
--- a/src/Entrust/EntrustServiceProvider.php
+++ b/src/Entrust/EntrustServiceProvider.php
@@ -60,29 +60,29 @@ class EntrustServiceProvider extends ServiceProvider
     private function bladeDirectives()
     {
         // Call to Entrust::hasRole
-        Blade::directive('role', function($expression) {
+        \Blade::directive('role', function($expression) {
             return "<?php if (\\Entrust::hasRole{$expression}) : ?>";
         });
 
-        Blade::directive('endrole', function($expression) {
+        \Blade::directive('endrole', function($expression) {
             return "<?php endif; // Entrust::hasRole ?>";
         });
 
         // Call to Entrust::can
-        Blade::directive('permission', function($expression) {
+        \Blade::directive('permission', function($expression) {
             return "<?php if (\\Entrust::can{$expression}) : ?>";
         });
 
-        Blade::directive('endpermission', function($expression) {
+        \Blade::directive('endpermission', function($expression) {
             return "<?php endif; // Entrust::can ?>";
         });
 
         // Call to Entrust::ability
-        Blade::directive('ability', function($expression) {
+        \Blade::directive('ability', function($expression) {
             return "<?php if (\\Entrust::ability{$expression}) : ?>";
         });
 
-        Blade::directive('endability', function($expression) {
+        \Blade::directive('endability', function($expression) {
             return "<?php endif; // Entrust::ability ?>";
         });
     }


### PR DESCRIPTION
Right now returns:
```
PHP Fatal error:  Class 'Zizaco\Entrust\Blade' not found in /private/var/www/bonappetour/vendor/zizaco/entrust/src/Entrust/EntrustServiceProvider.php on line 63

[Symfony\Component\Debug\Exception\FatalErrorException] Class 'Zizaco\Entrust\Blade' not found
```