### PR TITLE
* Cache is now invalidated in more appropriate workflows.

### DIFF
--- a/src/Entrust/Traits/EntrustPermissionTrait.php
+++ b/src/Entrust/Traits/EntrustPermissionTrait.php
@@ -37,7 +37,7 @@ trait EntrustPermissionTrait
             if (!method_exists(Config::get('entrust.permission'), 'bootSoftDeletes')) {
                 $permission->roles()->sync([]);
             }
-
+            Cache::tags(Config::get('entrust.permission_role_table'))->flush();
             return true;
         });
     }

--- a/src/Entrust/Traits/EntrustRoleTrait.php
+++ b/src/Entrust/Traits/EntrustRoleTrait.php
@@ -131,6 +131,7 @@ trait EntrustRoleTrait
         } else {
             $this->perms()->detach();
         }
+        Cache::tags(Config::get('entrust.permission_role_table'))->flush();
     }
 
     /**
@@ -151,6 +152,7 @@ trait EntrustRoleTrait
         }
 
         $this->perms()->attach($permission);
+        Cache::tags(Config::get('entrust.permission_role_table'))->flush(); 
     }
 
     /**
@@ -169,6 +171,7 @@ trait EntrustRoleTrait
             $permission = $permission['id'];
 
         $this->perms()->detach($permission);
+        Cache::tags(Config::get('entrust.permission_role_table'))->flush(); 
     }
 
     /**

--- a/src/Entrust/Traits/EntrustRoleTrait.php
+++ b/src/Entrust/Traits/EntrustRoleTrait.php
@@ -25,17 +25,17 @@ trait EntrustRoleTrait
     public function save(array $options = [])
     {   //both inserts and updates
         parent::save($options);
-        Cache::tags(Config::get('entrust.permission_role_table'))->flush();
+        
     }
     public function delete(array $options = [])
     {   //soft or hard
         parent::delete($options);
-        Cache::tags(Config::get('entrust.permission_role_table'))->flush();
+        $this->clearPermissionRoleCache();
     }
     public function restore()
     {   //soft delete undo's
         parent::restore();
-        Cache::tags(Config::get('entrust.permission_role_table'))->flush();
+        $this->clearPermissionRoleCache();
     }
     
     /**
@@ -131,7 +131,7 @@ trait EntrustRoleTrait
         } else {
             $this->perms()->detach();
         }
-        Cache::tags(Config::get('entrust.permission_role_table'))->flush();
+        $this->clearPermissionRoleCache();
     }
 
     /**
@@ -152,7 +152,7 @@ trait EntrustRoleTrait
         }
 
         $this->perms()->attach($permission);
-        Cache::tags(Config::get('entrust.permission_role_table'))->flush(); 
+        $this->clearPermissionRoleCache();
     }
 
     /**
@@ -171,7 +171,7 @@ trait EntrustRoleTrait
             $permission = $permission['id'];
 
         $this->perms()->detach($permission);
-        Cache::tags(Config::get('entrust.permission_role_table'))->flush(); 
+        $this->clearPermissionRoleCache();
     }
 
     /**
@@ -200,5 +200,9 @@ trait EntrustRoleTrait
         foreach ($permissions as $permission) {
             $this->detachPermission($permission);
         }
+    }
+    
+    private function clearPermissionRoleCache() {
+        Cache::tags(Config::get('entrust.permission_role_table'))->flush();
     }
 }

--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -230,6 +230,7 @@ trait EntrustUserTrait
         }
 
         $this->roles()->attach($role);
+        Cache::tags(Config::get('entrust.role_user_table'))->flush();
     }
 
     /**
@@ -248,6 +249,7 @@ trait EntrustUserTrait
         }
 
         $this->roles()->detach($role);
+        Cache::tags(Config::get('entrust.role_user_table'))->flush();
     }
 
     /**
@@ -260,6 +262,7 @@ trait EntrustUserTrait
         foreach ($roles as $role) {
             $this->attachRole($role);
         }
+        Cache::tags(Config::get('entrust.role_user_table'))->flush();
     }
 
     /**
@@ -274,6 +277,7 @@ trait EntrustUserTrait
         foreach ($roles as $role) {
             $this->detachRole($role);
         }
+        Cache::tags(Config::get('entrust.role_user_table'))->flush();
     }
 
 }

--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -26,17 +26,17 @@ trait EntrustUserTrait
     public function save(array $options = [])
     {   //both inserts and updates
         parent::save($options);
-        Cache::tags(Config::get('entrust.role_user_table'))->flush();
+        $this->clearRoleUserCache();
     }
     public function delete(array $options = [])
     {   //soft or hard
         parent::delete($options);
-        Cache::tags(Config::get('entrust.role_user_table'))->flush();
+        $this->clearRoleUserCache();
     }
     public function restore()
     {   //soft delete undo's
         parent::restore();
-        Cache::tags(Config::get('entrust.role_user_table'))->flush();
+        $this->clearRoleUserCache();
     }
     
     /**
@@ -230,7 +230,7 @@ trait EntrustUserTrait
         }
 
         $this->roles()->attach($role);
-        Cache::tags(Config::get('entrust.role_user_table'))->flush();
+        $this->clearRoleUserCache();
     }
 
     /**
@@ -249,7 +249,7 @@ trait EntrustUserTrait
         }
 
         $this->roles()->detach($role);
-        Cache::tags(Config::get('entrust.role_user_table'))->flush();
+        $this->clearRoleUserCache();
     }
 
     /**
@@ -262,7 +262,6 @@ trait EntrustUserTrait
         foreach ($roles as $role) {
             $this->attachRole($role);
         }
-        Cache::tags(Config::get('entrust.role_user_table'))->flush();
     }
 
     /**
@@ -277,7 +276,9 @@ trait EntrustUserTrait
         foreach ($roles as $role) {
             $this->detachRole($role);
         }
-        Cache::tags(Config::get('entrust.role_user_table'))->flush();
     }
 
+    private function clearRoleUserCache() {
+        Cache::tags(Config::get('entrust.role_user_table'))->flush();
+    }
 }

--- a/tests/EntrustUserTest.php
+++ b/tests/EntrustUserTest.php
@@ -1009,9 +1009,6 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         | Expectation
         |------------------------------------------------------------
         */
-        Config::shouldReceive('get')->with('entrust.role_user_table')->times(1)->andReturn('role_user');
-        Cache::shouldReceive('tags->flush')->times(1);
-
         $user->shouldReceive('attachRole')
             ->with(1)
             ->once()->ordered();
@@ -1044,9 +1041,6 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         | Expectation
         |------------------------------------------------------------
         */
-        Config::shouldReceive('get')->with('entrust.role_user_table')->times(1)->andReturn('role_user');
-        Cache::shouldReceive('tags->flush')->times(1);
-
         $user->shouldReceive('detachRole')
             ->with(1)
             ->once()->ordered();
@@ -1086,10 +1080,9 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         |------------------------------------------------------------
         */
         Config::shouldReceive('get')->with('entrust.role')->once()->andReturn('App\Role');
-        Config::shouldReceive('get')->with('entrust.role_user_table')->times(2)->andReturn('role_user');
+        Config::shouldReceive('get')->with('entrust.role_user_table')->once()->andReturn('role_user');
         Config::shouldReceive('get')->with('entrust.user_foreign_key')->once()->andReturn('user_id');
         Config::shouldReceive('get')->with('entrust.role_foreign_key')->once()->andReturn('role_id');
-        Cache::shouldReceive('tags->flush')->times(1);
 
         $relationship->shouldReceive('get')
                      ->andReturn($user->roles)->once();

--- a/tests/EntrustUserTest.php
+++ b/tests/EntrustUserTest.php
@@ -921,6 +921,9 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         | Expectation
         |------------------------------------------------------------
         */
+        Config::shouldReceive('get')->with('entrust.role_user_table')->times(3)->andReturn('role_user');
+        Cache::shouldReceive('tags->flush')->times(3);
+        
         $roleObject->shouldReceive('getKey')
             ->andReturn(1);
 
@@ -963,6 +966,9 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         | Expectation
         |------------------------------------------------------------
         */
+        Config::shouldReceive('get')->with('entrust.role_user_table')->times(3)->andReturn('role_user');
+        Cache::shouldReceive('tags->flush')->times(3);
+
         $roleObject->shouldReceive('getKey')
             ->andReturn(1);
 
@@ -1003,6 +1009,9 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         | Expectation
         |------------------------------------------------------------
         */
+        Config::shouldReceive('get')->with('entrust.role_user_table')->times(1)->andReturn('role_user');
+        Cache::shouldReceive('tags->flush')->times(1);
+
         $user->shouldReceive('attachRole')
             ->with(1)
             ->once()->ordered();
@@ -1035,6 +1044,9 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         | Expectation
         |------------------------------------------------------------
         */
+        Config::shouldReceive('get')->with('entrust.role_user_table')->times(1)->andReturn('role_user');
+        Cache::shouldReceive('tags->flush')->times(1);
+
         $user->shouldReceive('detachRole')
             ->with(1)
             ->once()->ordered();
@@ -1074,9 +1086,10 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         |------------------------------------------------------------
         */
         Config::shouldReceive('get')->with('entrust.role')->once()->andReturn('App\Role');
-        Config::shouldReceive('get')->with('entrust.role_user_table')->once()->andReturn('role_user');
+        Config::shouldReceive('get')->with('entrust.role_user_table')->times(2)->andReturn('role_user');
         Config::shouldReceive('get')->with('entrust.user_foreign_key')->once()->andReturn('user_id');
         Config::shouldReceive('get')->with('entrust.role_foreign_key')->once()->andReturn('role_id');
+        Cache::shouldReceive('tags->flush')->times(1);
 
         $relationship->shouldReceive('get')
                      ->andReturn($user->roles)->once();


### PR DESCRIPTION
Before, it was only invalidating the cache when updating the User or the Role itself. Now it also invalidates the caches when roles or permissions are attached/detached as well.
