### PR TITLE
use trait booting rather than overriding the entire boot

### DIFF
--- a/src/Entrust/Traits/EntrustPermissionTrait.php
+++ b/src/Entrust/Traits/EntrustPermissionTrait.php
@@ -29,10 +29,8 @@ trait EntrustPermissionTrait
      *
      * @return void|bool
      */
-    public static function boot()
+    public static function bootEntrustPermissionTrait()
     {
-        parent::boot();
-
         static::deleting(function($permission) {
             if (!method_exists(Config::get('entrust.permission'), 'bootSoftDeletes')) {
                 $permission->roles()->sync([]);

--- a/src/Entrust/Traits/EntrustRoleTrait.php
+++ b/src/Entrust/Traits/EntrustRoleTrait.php
@@ -67,10 +67,8 @@ trait EntrustRoleTrait
      *
      * @return void|bool
      */
-    public static function boot()
+    public static function bootEntrustRoleTrait()
     {
-        parent::boot();
-
         static::deleting(function($role) {
             if (!method_exists(Config::get('entrust.role'), 'bootSoftDeletes')) {
                 $role->users()->sync([]);

--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -56,10 +56,8 @@ trait EntrustUserTrait
      *
      * @return void|bool
      */
-    public static function boot()
+    public static function bootEntrustUserTrait()
     {
-        parent::boot();
-
         static::deleting(function($user) {
             if (!method_exists(Config::get('auth.model'), 'bootSoftDeletes')) {
                 $user->roles()->sync([]);


### PR DESCRIPTION
for some reason the traits overrode the whole boot instead of just using the trait boots.

This meant that if there was already a `boot` it would conflict.
