### PR TITLE
Fix model save/delete/restore return values lost

### DIFF
--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -25,18 +25,21 @@ trait EntrustUserTrait
     }
     public function save(array $options = [])
     {   //both inserts and updates
-        parent::save($options);
+        $result = parent::save($options);
         Cache::tags(Config::get('entrust.role_user_table'))->flush();
+        return $result;
     }
     public function delete(array $options = [])
     {   //soft or hard
-        parent::delete($options);
+        $result = parent::delete($options);
         Cache::tags(Config::get('entrust.role_user_table'))->flush();
+        return $result;
     }
     public function restore()
     {   //soft delete undo's
-        parent::restore();
+        $result = parent::restore();
         Cache::tags(Config::get('entrust.role_user_table'))->flush();
+        return $result;
     }
     
     /**


### PR DESCRIPTION
Eloquent save/delete/restore return values but these were lost when using EntrustUserTrait
