### PR TITLE
Permission foreign key

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ to your composer.json. Then run `composer install` or `composer update`.
 
 Then in your `config/app.php` add
 ```php
-    'Zizaco\Entrust\EntrustServiceProvider'
+    Zizaco\Entrust\EntrustServiceProvider::class
 ```
 in the `providers` array and
 ```php
-    Zizaco\Entrust\EntrustServiceProvider::class
+    'Entrust' => Zizaco\Entrust\EntrustFacade::class
 ```
 to the `aliases` array.
 

--- a/src/Entrust/Traits/EntrustRoleTrait.php
+++ b/src/Entrust/Traits/EntrustRoleTrait.php
@@ -57,7 +57,7 @@ trait EntrustRoleTrait
      */
     public function perms()
     {
-        return $this->belongsToMany(Config::get('entrust.permission'), Config::get('entrust.permission_role_table'));
+        return $this->belongsToMany(Config::get('entrust.permission'), Config::get('entrust.permission_role_table'), Config::get('entrust.role_foreign_key'), Config::get('entrust.permission_foreign_key'));
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -84,9 +84,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Role Foreign key on Entrust's role_user Table (Pivot)
+    | Role Foreign key on Entrust's role_user and permission_role Tables (Pivot)
     |--------------------------------------------------------------------------
     */
     'role_foreign_key' => 'role_id',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Permission Foreign key on Entrust's permission_role Table (Pivot)
+    |--------------------------------------------------------------------------
+    */
+    'permission_foreign_key' => 'permission_id',
 ];


### PR DESCRIPTION
If the Model classes for Permission and Role are not named as such, trying to get all permission for a role will throw an error because eloquent constructs the foreign keys from the model class name.
The user relationship already uses a config option to get the foreign keys.