### PR TITLE
Solving Issue: Class name must be a valid object or a string

### DIFF
--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -81,8 +81,8 @@ class MigrationCommand extends Command
     {
         $migrationFile = base_path("/database/migrations")."/".date('Y_m_d_His')."_entrust_setup_tables.php";
 
-        $usersTable  = Config::get('auth.table');
-        $userModel   = Config::get('auth.model');
+        $usersTable  = Config::get('auth.providers.users.table');
+        $userModel   = Config::get('auth.providers.users.model');
         $userKeyName = (new $userModel())->getKeyName();
 
         $data = compact('rolesTable', 'roleUserTable', 'permissionsTable', 'permissionRoleTable', 'usersTable', 'userKeyName');


### PR DESCRIPTION
Solving Entrust migration issue with Laravel 5.2
`php artisan entrust:migration`

> [Symfony\Component\Debug\Exception\FatalErrorException]
> Class name must be a valid object or a string