### PR TITLE
Update config path for Laravel 5.2

### DIFF
--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -81,8 +81,8 @@ class MigrationCommand extends Command
     {
         $migrationFile = base_path("/database/migrations")."/".date('Y_m_d_His')."_entrust_setup_tables.php";
 
-        $usersTable  = Config::get('auth.table');
-        $userModel   = Config::get('auth.model');
+        $usersTable  = Config::get('auth.providers.users.table');
+        $userModel   = Config::get('auth.providers.users.model');
         $userKeyName = (new $userModel())->getKeyName();
 
         $data = compact('rolesTable', 'roleUserTable', 'permissionsTable', 'permissionRoleTable', 'usersTable', 'userKeyName');


### PR DESCRIPTION
This PR updates the config path in the entrust:migration command to use the new auth path in Laravel 5.2.

One issue though is that the createMigration method is relying on an "auth.table" config which, from what I can see, no longer exists on Laravel 5.2, maybe we should move this to Entrust's config?