### PR TITLE
Fix typo in README.md at middleware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ to the `aliases` array.
 
 If you are going to use [Middleware](#middleware) (requires Laravel 5.1 or later) you also need to add
 ```php
-    'role' => Zizaco\Entrust\Middleware\EntrustRole::class,
-    'permission' => Zizaco\Entrust\Middleware\EntrustPermission::class,
-    'ability' => Zizaco\Entrust\Middleware\EntrustAbility::class,
+    'role' => \Zizaco\Entrust\Middleware\EntrustRole::class,
+    'permission' => \Zizaco\Entrust\Middleware\EntrustPermission::class,
+    'ability' => \Zizaco\Entrust\Middleware\EntrustAbility::class,
 ```
 to `routeMiddleware` array in `app/Http/Kernel.php`.
 


### PR DESCRIPTION
Middleware route need backslash at the front, otherwise, middleware will not be registered.