### PR TITLE
Fall back to the default users table in case it's not defined

### DIFF
--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -81,7 +81,7 @@ class MigrationCommand extends Command
     {
         $migrationFile = base_path("/database/migrations")."/".date('Y_m_d_His')."_entrust_setup_tables.php";
 
-        $usersTable  = Config::get('auth.providers.users.table');
+        $usersTable  = Config::get('auth.providers.users.table') ?: 'users';
         $userModel   = Config::get('auth.providers.users.model');
         $userKeyName = (new $userModel())->getKeyName();
 


### PR DESCRIPTION
When generating the Entrust migration, fall back to the default users table in case it's not defined.
Solves #544, #510, #462.

Cheers