### PR TITLE
Bypass cache when file or database cache drivers are set

### DIFF
--- a/tests/EntrustUserTest.php
+++ b/tests/EntrustUserTest.php
@@ -2,6 +2,7 @@
 
 use Zizaco\Entrust\Contracts\EntrustUserInterface;
 use Zizaco\Entrust\Traits\EntrustUserTrait;
+use Illuminate\Cache\ArrayStore;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Cache;
 use Zizaco\Entrust\Permission;
@@ -11,23 +12,23 @@ use Mockery as m;
 class EntrustUserTest extends PHPUnit_Framework_TestCase
 {
     private $facadeMocks = array();
-    
+
     public function setUp()
     {
         parent::setUp();
-        
+
         $app = m::mock('app')->shouldReceive('instance')->getMock();
-        
+
         $this->facadeMocks['config'] = m::mock('config');
         $this->facadeMocks['cache'] = m::mock('cache');
-        
+
         Config::setFacadeApplication($app);
         Config::swap($this->facadeMocks['config']);
-        
+
         Cache::setFacadeApplication($app);
         Cache::swap($this->facadeMocks['cache']);
     }
-    
+
     public function tearDown()
     {
         m::close();
@@ -91,6 +92,7 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         Config::shouldReceive('get')->with('entrust.role_user_table')->times(9)->andReturn('role_user');
         Config::shouldReceive('get')->with('cache.ttl')->times(9)->andReturn('1440');
         Cache::shouldReceive('tags->remember')->times(9)->andReturn($user->roles);
+        Cache::shouldReceive('getStore')->times(9)->andReturn(new ArrayStore);
 
         /*
         |------------------------------------------------------------
@@ -137,6 +139,7 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         Config::shouldReceive('get')->with('entrust.role_user_table')->times(11)->andReturn('role_user');
         Config::shouldReceive('get')->with('cache.ttl')->times(11)->andReturn('1440');
         Cache::shouldReceive('tags->remember')->times(11)->andReturn($user->roles);
+        Cache::shouldReceive('getStore')->times(11)->andReturn(new ArrayStore);
 
         /*
         |------------------------------------------------------------
@@ -182,6 +185,7 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         Config::shouldReceive('get')->with('entrust.role_user_table')->times(6)->andReturn('role_user');
         Config::shouldReceive('get')->with('cache.ttl')->times(6)->andReturn('1440');
         Cache::shouldReceive('tags->remember')->times(6)->andReturn($user->roles);
+        Cache::shouldReceive('getStore')->times(6)->andReturn(new ArrayStore);
 
         /*
         |------------------------------------------------------------
@@ -196,8 +200,8 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($user->can(['admin.*']));
         $this->assertFalse($user->can(['site.*']));
     }
-    
-    
+
+
     public function testAbilityShouldReturnBoolean()
     {
         /*
@@ -240,7 +244,8 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         Config::shouldReceive('get')->with('entrust.role_user_table')->times(32)->andReturn('role_user');
         Config::shouldReceive('get')->with('cache.ttl')->times(32)->andReturn('1440');
         Cache::shouldReceive('tags->remember')->times(32)->andReturn($user->roles);
-        
+        Cache::shouldReceive('getStore')->times(32)->andReturn(new ArrayStore);
+
         $user->shouldReceive('hasRole')
             ->with(m::anyOf($userRoleNameA, $userRoleNameB), m::anyOf(true, false))
             ->andReturn(true);
@@ -363,7 +368,8 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         Config::shouldReceive('get')->with('entrust.role_user_table')->times(32)->andReturn('role_user');
         Config::shouldReceive('get')->with('cache.ttl')->times(32)->andReturn('1440');
         Cache::shouldReceive('tags->remember')->times(32)->andReturn($user->roles);
-        
+        Cache::shouldReceive('getStore')->times(32)->andReturn(new ArrayStore);
+
         $user->shouldReceive('hasRole')
             ->with(m::anyOf($userRoleNameA, $userRoleNameB), m::anyOf(true, false))
             ->andReturn(true);
@@ -524,7 +530,8 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         Config::shouldReceive('get')->with('entrust.role_user_table')->times(32)->andReturn('role_user');
         Config::shouldReceive('get')->with('cache.ttl')->times(32)->andReturn('1440');
         Cache::shouldReceive('tags->remember')->times(32)->andReturn($user->roles);
-        
+        Cache::shouldReceive('getStore')->times(32)->andReturn(new ArrayStore);
+
         $user->shouldReceive('hasRole')
             ->with(m::anyOf($userRoleNameA, $userRoleNameB), m::anyOf(true, false))
             ->andReturn(true);
@@ -699,7 +706,8 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         Config::shouldReceive('get')->with('entrust.role_user_table')->times(8)->andReturn('role_user');
         Config::shouldReceive('get')->with('cache.ttl')->times(8)->andReturn('1440');
         Cache::shouldReceive('tags->remember')->times(8)->andReturn($user->roles);
-        
+        Cache::shouldReceive('getStore')->times(8)->andReturn(new ArrayStore);
+
         $user->shouldReceive('hasRole')
             ->with(m::anyOf('UserRoleA', 'UserRoleB'), m::anyOf(true, false))
             ->andReturn(true);
@@ -774,7 +782,8 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         Config::shouldReceive('get')->with('entrust.role_user_table')->times(32)->andReturn('role_user');
         Config::shouldReceive('get')->with('cache.ttl')->times(32)->andReturn('1440');
         Cache::shouldReceive('tags->remember')->times(32)->andReturn($user->roles);
-        
+        Cache::shouldReceive('getStore')->times(32)->andReturn(new ArrayStore);
+
         $user->shouldReceive('hasRole')
             ->with(m::anyOf($userRoleNameA, $userRoleNameB), m::anyOf(true, false))
             ->andReturn(true);
@@ -1124,7 +1133,7 @@ class HasRoleUser implements EntrustUserInterface
     public $roles;
     public $primaryKey;
     public $id;
-    
+
     public function __construct() {
         $this->primaryKey = 'id';
         $this->id = 4;


### PR DESCRIPTION
Bypass cache when `file` or `database` cache drivers are set.
Solves #541, #537, #450, #422.