### PR TITLE
Clean up Middleware parameter handling

### DIFF
--- a/src/Entrust/Middleware/EntrustAbility.php
+++ b/src/Entrust/Middleware/EntrustAbility.php
@@ -13,6 +13,8 @@ use Illuminate\Contracts\Auth\Guard;
 
 class EntrustAbility
 {
+	const DELIMITER = '|';
+
 	protected $auth;
 
 	/**
@@ -37,7 +39,19 @@ class EntrustAbility
 	 */
 	public function handle($request, Closure $next, $roles, $permissions, $validateAll = false)
 	{
-		if ($this->auth->guest() || !$request->user()->ability(explode('|', $roles), explode('|', $permissions), array('validate_all' => $validateAll))) {
+		if (!is_array($roles)) {
+			$roles = explode(self::DELIMITER, $roles);
+		}
+
+		if (!is_array($permissions)) {
+			$permissions = explode(self::DELIMITER, $permissions);
+		}
+
+		if (!is_bool($validateAll)) {
+			$validateAll = filter_var($validateAll, FILTER_VALIDATE_BOOLEAN);
+		}
+
+		if ($this->auth->guest() || !$request->user()->ability($roles, $permissions, [ 'validate_all' => $validateAll ])) {
 			abort(403);
 		}
 

--- a/src/Entrust/Middleware/EntrustPermission.php
+++ b/src/Entrust/Middleware/EntrustPermission.php
@@ -13,6 +13,8 @@ use Illuminate\Contracts\Auth\Guard;
 
 class EntrustPermission
 {
+	const DELIMITER = '|';
+
 	protected $auth;
 
 	/**
@@ -35,7 +37,11 @@ class EntrustPermission
 	 */
 	public function handle($request, Closure $next, $permissions)
 	{
-		if ($this->auth->guest() || !$request->user()->can(explode('|', $permissions))) {
+		if (!is_array($permissions)) {
+			$permissions = explode(self::DELIMITER, $permissions);
+		}
+
+		if ($this->auth->guest() || !$request->user()->can($permissions)) {
 			abort(403);
 		}
 

--- a/src/Entrust/Middleware/EntrustRole.php
+++ b/src/Entrust/Middleware/EntrustRole.php
@@ -13,6 +13,8 @@ use Illuminate\Contracts\Auth\Guard;
 
 class EntrustRole
 {
+	const DELIMITER = '|';
+
 	protected $auth;
 
 	/**
@@ -35,7 +37,11 @@ class EntrustRole
 	 */
 	public function handle($request, Closure $next, $roles)
 	{
-		if ($this->auth->guest() || !$request->user()->hasRole(explode('|', $roles))) {
+		if (!is_array($roles)) {
+			$roles = explode(self::DELIMITER, $roles);
+		}
+
+		if ($this->auth->guest() || !$request->user()->hasRole($roles)) {
 			abort(403);
 		}
 


### PR DESCRIPTION
This updates the middleware to handle the parameters accepted a
little better - includes only `explode`ing the values when needed
and also coercing items expected to be `bool` with `filter_var`

Fixes issues #575
