### PR TITLE
Make compatible with Lumen for #369.

### DIFF
--- a/src/Entrust/EntrustServiceProvider.php
+++ b/src/Entrust/EntrustServiceProvider.php
@@ -28,7 +28,7 @@ class EntrustServiceProvider extends ServiceProvider
     {
         // Publish config files
         $this->publishes([
-            __DIR__.'/../config/config.php' => config_path('entrust.php'),
+            __DIR__.'/../config/config.php' => app()->basePath() . '/config/entrust.php',
         ]);
 
         // Register commands
@@ -59,6 +59,8 @@ class EntrustServiceProvider extends ServiceProvider
      */
     private function bladeDirectives()
     {
+        if (!class_exists('\Blade')) return;
+
         // Call to Entrust::hasRole
         \Blade::directive('role', function($expression) {
             return "<?php if (\\Entrust::hasRole{$expression}) : ?>";


### PR DESCRIPTION
Lumen does not provide the `config_path()` helper by default, so use the manual version instead, since this is the only time Entrust uses config_path.
Also abort setting Blade directives if Blade is not available.
