### PR TITLE
Prevent migration crash

### DIFF
--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -83,7 +83,11 @@ class MigrationCommand extends Command
 
         $usersTable  = Config::get('auth.providers.users.table');
         $userModel   = Config::get('auth.providers.users.model');
-        $userKeyName = (new $userModel())->getKeyName();
+        $userModel   = new $userModel();
+        $userKeyName = $userModel->getKeyName();
+        if(!empty($usersTable)) {
+            $usersTable = $userModel->getTable();
+        }
 
         $data = compact('rolesTable', 'roleUserTable', 'permissionsTable', 'permissionRoleTable', 'usersTable', 'userKeyName');
 

--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -85,7 +85,7 @@ class MigrationCommand extends Command
         $userModel   = Config::get('auth.providers.users.model');
         $userModel   = new $userModel();
         $userKeyName = $userModel->getKeyName();
-        if(!empty($usersTable)) {
+        if(empty($usersTable)) {
             $usersTable = $userModel->getTable();
         }
 


### PR DESCRIPTION
When config contains only user model, but haven't table variable, migration can be generated with empty $usersTable.
So we get error while processing migrate

![4e368cc1b7fb7f9cc3148e07070f](https://cloud.githubusercontent.com/assets/1709666/16196457/b2080408-3706-11e6-8978-8669b6e4fcd2.png)
