### PR TITLE
Fixed Config for Laravel 5.2 and later 

### DIFF
--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -81,9 +81,9 @@ class MigrationCommand extends Command
     {
         $migrationFile = base_path("/database/migrations")."/".date('Y_m_d_His')."_entrust_setup_tables.php";
 
-        $usersTable  = Config::get('auth.table');
-        $userModel   = Config::get('auth.model');
-        $userKeyName = (new $userModel())->getKeyName();
+        $usersTable  = Config::get('entrust.users_table');
+        $userModel   = Config::get('entrust.user');
+        $userKeyName = (new $userModel)->getKeyName();
 
         $data = compact('rolesTable', 'roleUserTable', 'permissionsTable', 'permissionRoleTable', 'usersTable', 'userKeyName');
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -33,6 +33,28 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application User Model
+    |--------------------------------------------------------------------------
+    |
+    | This is the User model used by Entrust to create correct relations.
+    | Update the User if it is in a different namespace.
+    |
+    */
+    'user' => 'App\User',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Users Table
+    |--------------------------------------------------------------------------
+    |
+    | This is the users table used by the application to save users to the
+    | database.
+    |
+    */
+    'users_table' => 'users',
+
+    /*
+    |--------------------------------------------------------------------------
     | Entrust Permission Model
     |--------------------------------------------------------------------------
     |
@@ -75,24 +97,5 @@ return [
     */
     'role_user_table' => 'role_user',
 
-    /*
-    |--------------------------------------------------------------------------
-    | User Foreign key on Entrust's role_user Table (Pivot)
-    |--------------------------------------------------------------------------
-    */
-    'user_foreign_key' => 'user_id',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Role Foreign key on Entrust's role_user and permission_role Tables (Pivot)
-    |--------------------------------------------------------------------------
-    */
-    'role_foreign_key' => 'role_id',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Permission Foreign key on Entrust's permission_role Table (Pivot)
-    |--------------------------------------------------------------------------
-    */
-    'permission_foreign_key' => 'permission_id',
 ];


### PR DESCRIPTION
This error is thrown on Laravel 5.2. The user model path and users table are not defined in confg\auth.php so I added these to the entrust config file. when a user publishes entrust, they can edit this value if their user table or model is named different than laravel expects. 
  [Symfony\Component\Debug\Exception\FatalThrowableError]
  Class name must be a valid object or a string
