### PR TITLE
Fix for migration missing table name

### DIFF
--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -81,9 +81,10 @@ class MigrationCommand extends Command
     {
         $migrationFile = base_path("/database/migrations")."/".date('Y_m_d_His')."_entrust_setup_tables.php";
 
-        $usersTable  = Config::get('auth.providers.users.table');
-        $userModel   = Config::get('auth.providers.users.model');
-        $userKeyName = (new $userModel())->getKeyName();
+        $userModel = Config::get('auth.providers.users.model');
+        $userModel = new $userModel;
+        $userKeyName = $userModel->getKeyName();
+        $usersTable  = $userModel->getTable();
 
         $data = compact('rolesTable', 'roleUserTable', 'permissionsTable', 'permissionRoleTable', 'usersTable', 'userKeyName');
 


### PR DESCRIPTION
The table name is not set as 'auth.providers.users.model' in atleast Laravel 5.2.41. But since we got the model anyway. Why no use ->getTable(); Tested & Working.
