### PR TITLE
fixed MigrationCommand User Table = null

### DIFF
--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -81,9 +81,10 @@ class MigrationCommand extends Command
     {
         $migrationFile = base_path("/database/migrations")."/".date('Y_m_d_His')."_entrust_setup_tables.php";
 
-        $usersTable  = Config::get('auth.providers.users.table');
-        $userModel   = Config::get('auth.providers.users.model');
-        $userKeyName = (new $userModel())->getKeyName();
+        $userModelName = Config::get('auth.providers.users.model');
+        $userModel = new $userModelName();
+        $usersTable = $userModel->getTable();
+        $userKeyName = $userModel->getKeyName();
 
         $data = compact('rolesTable', 'roleUserTable', 'permissionsTable', 'permissionRoleTable', 'usersTable', 'userKeyName');
 


### PR DESCRIPTION
#638

Creating the entrust migration with `entrust:migration' still creates an reference on empty table.

``` php
$table->foreign('user_id')->references('id')->on('')
                ->onUpdate('cascade')->onDelete('cascade');
```

Got this fixed.
