### PR TITLE
Fixed missing parenthesis on Blade directives

### DIFF
--- a/src/Entrust/EntrustServiceProvider.php
+++ b/src/Entrust/EntrustServiceProvider.php
@@ -1,4 +1,6 @@
-<?php namespace Zizaco\Entrust;
+<?php 
+
+namespace Zizaco\Entrust;
 
 /**
  * This file is part of Entrust,
@@ -61,7 +63,7 @@ class EntrustServiceProvider extends ServiceProvider
     {
         // Call to Entrust::hasRole
         \Blade::directive('role', function($expression) {
-            return "<?php if (\\Entrust::hasRole{$expression}) : ?>";
+            return "<?php if (\\Entrust::hasRole({$expression})) : ?>";
         });
 
         \Blade::directive('endrole', function($expression) {
@@ -70,7 +72,7 @@ class EntrustServiceProvider extends ServiceProvider
 
         // Call to Entrust::can
         \Blade::directive('permission', function($expression) {
-            return "<?php if (\\Entrust::can{$expression}) : ?>";
+            return "<?php if (\\Entrust::can({$expression})) : ?>";
         });
 
         \Blade::directive('endpermission', function($expression) {
@@ -79,7 +81,7 @@ class EntrustServiceProvider extends ServiceProvider
 
         // Call to Entrust::ability
         \Blade::directive('ability', function($expression) {
-            return "<?php if (\\Entrust::ability{$expression}) : ?>";
+            return "<?php if (\\Entrust::ability({$expression})) : ?>";
         });
 
         \Blade::directive('endability', function($expression) {


### PR DESCRIPTION
Fixed blade directives: added missing parenthesis on all blade directives for L5.3.

Note: this has not been tested. Please test before merging.