### PR TITLE
fix: savePermissions method add flush cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zizaco/entrust",
+    "name": "scolib/entrust",
     "description": "This package provides a flexible way to add Role-based Permissions to Laravel",
     "keywords": ["laravel","illuminate","auth","roles","acl","permission"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,17 @@
         {
             "name": "Michele Angioni",
             "email": "michele.angioni@gmail.com"
+        },
+        {
+            "name": "klgd",
+            "email": "slice1213@gmail.com"
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "illuminate/console": "~5.0",
-        "illuminate/support": "~5.0",
-        "illuminate/cache": "~5.0"
+        "php": ">=5.6.4",
+        "illuminate/console": "~5.3",
+        "illuminate/support": "~5.3",
+        "illuminate/cache": "~5.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",

--- a/src/Entrust/EntrustServiceProvider.php
+++ b/src/Entrust/EntrustServiceProvider.php
@@ -61,7 +61,7 @@ class EntrustServiceProvider extends ServiceProvider
     {
         // Call to Entrust::hasRole
         \Blade::directive('role', function($expression) {
-            return "<?php if (\\Entrust::hasRole{$expression}) : ?>";
+            return "<?php if (\\Entrust::hasRole({$expression})) : ?>";
         });
 
         \Blade::directive('endrole', function($expression) {
@@ -70,7 +70,7 @@ class EntrustServiceProvider extends ServiceProvider
 
         // Call to Entrust::can
         \Blade::directive('permission', function($expression) {
-            return "<?php if (\\Entrust::can{$expression}) : ?>";
+            return "<?php if (\\Entrust::can({$expression})) : ?>";
         });
 
         \Blade::directive('endpermission', function($expression) {
@@ -79,7 +79,7 @@ class EntrustServiceProvider extends ServiceProvider
 
         // Call to Entrust::ability
         \Blade::directive('ability', function($expression) {
-            return "<?php if (\\Entrust::ability{$expression}) : ?>";
+            return "<?php if (\\Entrust::ability({$expression})) : ?>";
         });
 
         \Blade::directive('endability', function($expression) {

--- a/src/Entrust/Traits/EntrustRoleTrait.php
+++ b/src/Entrust/Traits/EntrustRoleTrait.php
@@ -150,6 +150,10 @@ trait EntrustRoleTrait
         } else {
             $this->perms()->detach();
         }
+
+        if(Cache::getStore() instanceof TaggableStore) {
+            Cache::tags(Config::get('entrust.permission_role_table'))->flush();
+        }
     }
 
     /**


### PR DESCRIPTION
When I only use savePermissions method save role's permission,  the cache is not cleared
