### PR TITLE
Update EntrustServiceProvider to fix Blade directives

### DIFF
--- a/src/Entrust/EntrustServiceProvider.php
+++ b/src/Entrust/EntrustServiceProvider.php
@@ -61,7 +61,7 @@ class EntrustServiceProvider extends ServiceProvider
     {
         // Call to Entrust::hasRole
         \Blade::directive('role', function($expression) {
-            return "<?php if (\\Entrust::hasRole{$expression}) : ?>";
+            return "<?php if (\\Entrust::hasRole({$expression})) : ?>";
         });
 
         \Blade::directive('endrole', function($expression) {
@@ -70,7 +70,7 @@ class EntrustServiceProvider extends ServiceProvider
 
         // Call to Entrust::can
         \Blade::directive('permission', function($expression) {
-            return "<?php if (\\Entrust::can{$expression}) : ?>";
+            return "<?php if (\\Entrust::can({$expression})) : ?>";
         });
 
         \Blade::directive('endpermission', function($expression) {
@@ -79,7 +79,7 @@ class EntrustServiceProvider extends ServiceProvider
 
         // Call to Entrust::ability
         \Blade::directive('ability', function($expression) {
-            return "<?php if (\\Entrust::ability{$expression}) : ?>";
+            return "<?php if (\\Entrust::ability({$expression})) : ?>";
         });
 
         \Blade::directive('endability', function($expression) {


### PR DESCRIPTION
The **( )** are missing in all the blade directives.

Current code Example: 
@role('admin')    =>    <?php if (\Entrust::hasRole'admin') : ?>

After this fix Example:
@role('admin')    =>    <?php if (\Entrust::hasRole**(**'admin'**)**) : ?>
