### PR TITLE
fixed role blade directive problem on Laravel 5.3

### DIFF
--- a/src/Entrust/EntrustServiceProvider.php
+++ b/src/Entrust/EntrustServiceProvider.php
@@ -61,7 +61,7 @@ class EntrustServiceProvider extends ServiceProvider
     {
         // Call to Entrust::hasRole
         \Blade::directive('role', function($expression) {
-            return "<?php if (\\Entrust::hasRole{$expression}) : ?>";
+            return "<?php if (\\Entrust::hasRole({$expression})) : ?>";
         });
 
         \Blade::directive('endrole', function($expression) {
@@ -70,7 +70,7 @@ class EntrustServiceProvider extends ServiceProvider
 
         // Call to Entrust::can
         \Blade::directive('permission', function($expression) {
-            return "<?php if (\\Entrust::can{$expression}) : ?>";
+            return "<?php if (\\Entrust::can({$expression})) : ?>";
         });
 
         \Blade::directive('endpermission', function($expression) {
@@ -79,7 +79,7 @@ class EntrustServiceProvider extends ServiceProvider
 
         // Call to Entrust::ability
         \Blade::directive('ability', function($expression) {
-            return "<?php if (\\Entrust::ability{$expression}) : ?>";
+            return "<?php if (\\Entrust::ability({$expression})) : ?>";
         });
 
         \Blade::directive('endability', function($expression) {


### PR DESCRIPTION
Hello, just applied a small fix on a bug caused on Laravel 5.3 using the Entrust blade directives.

The problem on Laravel < 5.3 was:
ex:
@role('admin')

Error: Parse error: syntax error, unexpected ''admin'' (T_CONSTANT_ENCAPSED_STRING)

Fix: just added a pair of '()' encapsulating the $expression, so you don't have to adjust every blade file with an extra pair of semicolons, like: @role(('admin')) when upgrading to Laravel 5.3
