### PR TITLE
call to auth.model in boot()

### DIFF
--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -71,7 +71,7 @@ trait EntrustUserTrait
         parent::boot();
 
         static::deleting(function($user) {
-            if (!method_exists(Config::get('auth.model'), 'bootSoftDeletes')) {
+            if (!method_exists(Config::get('auth.providers.users.model'), 'bootSoftDeletes')) {
                 $user->roles()->sync([]);
             }
 


### PR DESCRIPTION
On the last version, like in EntrustRoleTrait.php, there is a switch to Config::get('auth.providers.users.model') which is better than  Config::get('auth.model') that was not set, even following the install documentation. I looked for all the old calls in my code and found this call in dev-master. I think this is a mistake. So ... is it ?