### PR TITLE
Fixes Issue #352

### DIFF
--- a/src/Entrust/Traits/EntrustRoleTrait.php
+++ b/src/Entrust/Traits/EntrustRoleTrait.php
@@ -170,7 +170,7 @@ trait EntrustRoleTrait
         }
 
         if (is_array($permission)) {
-            $permission = $permission['id'];
+            return $this->attachPermissions($permission);
         }
 
         $this->perms()->attach($permission);
@@ -185,11 +185,13 @@ trait EntrustRoleTrait
      */
     public function detachPermission($permission)
     {
-        if (is_object($permission))
+        if (is_object($permission)) {
             $permission = $permission->getKey();
+        }
 
-        if (is_array($permission))
-            $permission = $permission['id'];
+        if (is_array($permission)) {
+            return $this->detachPermissions($permission);
+        }
 
         $this->perms()->detach($permission);
     }


### PR DESCRIPTION
Issue #352: Undefined index: id during attachPermission using array

Traits\EntrustRoleTrait:173 in attachPermission
    When input is determined to be an array, the function incorrectly attempts
    to get the value of the 'id' attribute instead of processing a list of
    Roles.  Fix calls attachPermissions on $permission instead, giving the
    desired functionality.

Traits\EntrustRoleTrait:192 in detachPermission
    See above.

Refactors Traits\EntrustRoleTrait:detachPermission to follow coding standard