### PR TITLE
Dont use cache.ttl due to unexpected behavior

### DIFF
--- a/src/Entrust/Traits/EntrustRoleTrait.php
+++ b/src/Entrust/Traits/EntrustRoleTrait.php
@@ -20,7 +20,7 @@ trait EntrustRoleTrait
         $rolePrimaryKey = $this->primaryKey;
         $cacheKey = 'entrust_permissions_for_role_'.$this->$rolePrimaryKey;
         if(Cache::getStore() instanceof TaggableStore) {
-            return Cache::tags(Config::get('entrust.permission_role_table'))->remember($cacheKey, Config::get('cache.ttl', 60), function () {
+            return Cache::tags(Config::get('entrust.permission_role_table'))->remember($cacheKey, Config::get('entrust.cache_ttl', 60), function () {
                 return $this->perms()->get();
             });
         }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -97,5 +97,19 @@ return [
     */
     'role_user_table' => 'role_user',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust permissions cache TTL
+    |--------------------------------------------------------------------------
+    |
+    | 
+    | If cache_ttl is a positive integer,
+    | Entrust will cache permissions in a configured cache storage.
+    |
+    | cache_ttl should be set in minutes and by default equals to null,
+    | which mean no caching
+    |
+    */
+    'cache_ttl' => null,
 
 ];


### PR DESCRIPTION
I've set up caching for my laravel application and it suddenly failed to run due to "Unsupported operand types" which was confusing and misleading because the only thing I've done setting cache.ttl:

```
'ttl' => [
    'products' => 10, # cache products for 10 minutes
    'listings' => 20, # cache listings for 20 minutes
];
```

in `config/cache.php`

I actually was surprised that Entrust uses `cache.ttl` which it really shouldn't.
`config/cache.php` is a good place to store USER-DEFINED cache settings like mine `cache.ttl.products`,

3rd parties should use own configuration to not interfere with user settings.

I propose store cache ttl for Entrust in `entrust.cache_ttl` (it's more explicit also).