### PR TITLE
Update EntrustUserTrait.php

### DIFF
--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -174,6 +174,15 @@ trait EntrustUserTrait
         if (!is_array($permissions)) {
             $permissions = explode(',', $permissions);
         }
+       
+         // convert the string provided into a boolean
+         // (bool) will return true if value is not null or 0 so ...
+        if($options['validate_all'] === 'false'){
+            $options['validate_all'] = false;
+        }
+        if($options['validate_all'] === 'true'){
+            $options['validate_all'] = true;
+        }
 
         // Set up default values and validate options.
         if (!isset($options['validate_all'])) {


### PR DESCRIPTION
Convert provided string to boolean if 'true' or 'false', when passing false value it is not recognised due to being a string on line 175 where strict checking is used !==

Fixed bug where passing false in the parameters for full matching fails because its not a boolean.