### PR TITLE
Fixed the soft deleting bug

### DIFF
--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -71,7 +71,7 @@ trait EntrustUserTrait
         parent::boot();
 
         static::deleting(function($user) {
-            if (!method_exists(Config::get('auth.model'), 'bootSoftDeletes')) {
+            if (!method_exists(Config::get('auth.providers.users.model'), 'bootSoftDeletes')) {
                 $user->roles()->sync([]);
             }
 


### PR DESCRIPTION
This commit fixes the bug reported in the issue #306 

In Laravel 5.2 the 'auth.model' config key has been changed to 'auth.providers.users.model'.