### PR TITLE
renamed 'can' method to 'permission' since it is in the laravel core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-
+dist: trusty
 php:
   - 5.5
   - 5.6

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ class User extends Eloquent
 }
 ```
 
-This will enable the relation with `Role` and add the following methods `roles()`, `hasRole($name)`, `can($permission)`, and `ability($roles, $permissions, $options)` within your `User` model.
+This will enable the relation with `Role` and add the following methods `roles()`, `hasRole($name)`, `permission($permission)`, and `ability($roles, $permissions, $options)` within your `User` model.
 
 Don't forget to dump composer autoload
 
@@ -262,15 +262,15 @@ Now we can check for roles and permissions simply by doing:
 ```php
 $user->hasRole('owner');   // false
 $user->hasRole('admin');   // true
-$user->can('edit-user');   // false
-$user->can('create-post'); // true
+$user->permission('edit-user');   // false
+$user->permission('create-post'); // true
 ```
 
-Both `hasRole()` and `can()` can receive an array of roles & permissions to check:
+Both `hasRole()` and `permission()` can receive an array of roles & permissions to check:
 
 ```php
 $user->hasRole(['owner', 'admin']);       // true
-$user->can(['edit-user', 'create-post']); // true
+$user->permission(['edit-user', 'create-post']); // true
 ```
 
 By default, if any of the roles or permissions are present for a user then the method will return true.
@@ -279,32 +279,32 @@ Passing `true` as a second parameter instructs the method to require **all** of 
 ```php
 $user->hasRole(['owner', 'admin']);             // true
 $user->hasRole(['owner', 'admin'], true);       // false, user does not have admin role
-$user->can(['edit-user', 'create-post']);       // true
-$user->can(['edit-user', 'create-post'], true); // false, user does not have edit-user permission
+$user->permission(['edit-user', 'create-post']);       // true
+$user->permission(['edit-user', 'create-post'], true); // false, user does not have edit-user permission
 ```
 
 You can have as many `Role`s as you want for each `User` and vice versa.
 
-The `Entrust` class has shortcuts to both `can()` and `hasRole()` for the currently logged in user:
+The `Entrust` class has shortcuts to both `permission()` and `hasRole()` for the currently logged in user:
 
 ```php
 Entrust::hasRole('role-name');
-Entrust::can('permission-name');
+Entrust::permission('permission-name');
 
 // is identical to
 
 Auth::user()->hasRole('role-name');
-Auth::user()->can('permission-name');
+Auth::user()->permission('permission-name');
 ```
 
 You can also use placeholders (wildcards) to check any matching permission by doing:
 
 ```php
 // match any admin permission
-$user->can("admin.*"); // true
+$user->permission("admin.*"); // true
 
 // match any permission about users
-$user->can("*_users"); // true
+$user->permission("*_users"); // true
 ```
 
 
@@ -388,7 +388,7 @@ Three directives are available for use within your Blade templates. What you giv
 
 @permission('manage-admins')
     <p>This is visible to users with the given permissions. Gets translated to 
-    \Entrust::can('manage-admins'). The @can directive is already taken by core 
+    \Entrust::permission('manage-admins'). The @can directive is already taken by core 
     laravel authorization package, hence the @permission directive instead.</p>
 @endpermission
 
@@ -479,7 +479,7 @@ Entrust roles/permissions can be used in filters by simply using the `can` and `
 Route::filter('manage_posts', function()
 {
     // check the current user
-    if (!Entrust::can('create-post')) {
+    if (!Entrust::permission('create-post')) {
         return Redirect::to('admin');
     }
 });
@@ -503,7 +503,7 @@ Route::filter('owner_role', function()
 Route::when('admin/advanced*', 'owner_role');
 ```
 
-As you can see `Entrust::hasRole()` and `Entrust::can()` checks if the user is logged in, and then if he or she has the role or permission.
+As you can see `Entrust::hasRole()` and `Entrust::permission()` checks if the user is logged in, and then if he or she has the role or permission.
 If the user is not logged the return will also be `false`.
 
 ## Troubleshooting

--- a/src/Entrust/Contracts/EntrustUserInterface.php
+++ b/src/Entrust/Contracts/EntrustUserInterface.php
@@ -35,7 +35,7 @@ interface EntrustUserInterface
      *
      * @return bool
      */
-    public function can($permission, $requireAll = false);
+    public function permission($permission, $requireAll = false);
 
     /**
      * Checks role(s) and permission(s).

--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -123,11 +123,11 @@ trait EntrustUserTrait
      *
      * @return bool
      */
-    public function can($permission, $requireAll = false)
+    public function permission($permission, $requireAll = false)
     {
         if (is_array($permission)) {
             foreach ($permission as $permName) {
-                $hasPerm = $this->can($permName);
+                $hasPerm = $this->permission($permName);
 
                 if ($hasPerm && !$requireAll) {
                     return true;
@@ -200,7 +200,7 @@ trait EntrustUserTrait
             $checkedRoles[$role] = $this->hasRole($role);
         }
         foreach ($permissions as $permission) {
-            $checkedPermissions[$permission] = $this->can($permission);
+            $checkedPermissions[$permission] = $this->permission($permission);
         }
 
         // If validate all and there is a false in either

--- a/tests/EntrustUserTest.php
+++ b/tests/EntrustUserTest.php
@@ -109,7 +109,7 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($user->hasRole(['RoleC', 'RoleD']));
     }
 
-    public function testCan()
+    public function testPermission()
     {
         /*
         |------------------------------------------------------------
@@ -146,19 +146,19 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         | Assertion
         |------------------------------------------------------------
         */
-        $this->assertTrue($user->can('manage_a'));
-        $this->assertTrue($user->can('manage_b'));
-        $this->assertTrue($user->can('manage_c'));
-        $this->assertFalse($user->can('manage_d'));
+        $this->assertTrue($user->permission('manage_a'));
+        $this->assertTrue($user->permission('manage_b'));
+        $this->assertTrue($user->permission('manage_c'));
+        $this->assertFalse($user->permission('manage_d'));
 
-        $this->assertTrue($user->can(['manage_a', 'manage_b', 'manage_c']));
-        $this->assertTrue($user->can(['manage_a', 'manage_b', 'manage_d']));
-        $this->assertFalse($user->can(['manage_a', 'manage_b', 'manage_d'], true));
-        $this->assertFalse($user->can(['manage_d', 'manage_e']));
+        $this->assertTrue($user->permission(['manage_a', 'manage_b', 'manage_c']));
+        $this->assertTrue($user->permission(['manage_a', 'manage_b', 'manage_d']));
+        $this->assertFalse($user->permission(['manage_a', 'manage_b', 'manage_d'], true));
+        $this->assertFalse($user->permission(['manage_d', 'manage_e']));
     }
 
 
-    public function testCanWithPlaceholderSupport ()
+    public function testPermissionWithPlaceholderSupport ()
     {
         /*
         |------------------------------------------------------------
@@ -192,13 +192,13 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         | Assertion
         |------------------------------------------------------------
         */
-        $this->assertTrue($user->can('admin.posts'));
-        $this->assertTrue($user->can('admin.pages'));
-        $this->assertTrue($user->can('admin.users'));
-        $this->assertFalse($user->can('admin.config'));
+        $this->assertTrue($user->permission('admin.posts'));
+        $this->assertTrue($user->permission('admin.pages'));
+        $this->assertTrue($user->permission('admin.users'));
+        $this->assertFalse($user->permission('admin.config'));
 
-        $this->assertTrue($user->can(['admin.*']));
-        $this->assertFalse($user->can(['site.*']));
+        $this->assertTrue($user->permission(['admin.*']));
+        $this->assertFalse($user->permission(['site.*']));
     }
 
 
@@ -252,10 +252,10 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         $user->shouldReceive('hasRole')
             ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
             ->andReturn(false);
-        $user->shouldReceive('can')
+        $user->shouldReceive('permission')
             ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
             ->andReturn(true);
-        $user->shouldReceive('can')
+        $user->shouldReceive('permission')
             ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
             ->andReturn(false);
 
@@ -376,10 +376,10 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         $user->shouldReceive('hasRole')
             ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
             ->andReturn(false);
-        $user->shouldReceive('can')
+        $user->shouldReceive('permission')
             ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
             ->andReturn(true);
-        $user->shouldReceive('can')
+        $user->shouldReceive('permission')
             ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
             ->andReturn(false);
 
@@ -538,10 +538,10 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         $user->shouldReceive('hasRole')
             ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
             ->andReturn(false);
-        $user->shouldReceive('can')
+        $user->shouldReceive('permission')
             ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
             ->andReturn(true);
-        $user->shouldReceive('can')
+        $user->shouldReceive('permission')
             ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
             ->andReturn(false);
 
@@ -714,10 +714,10 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         $user->shouldReceive('hasRole')
             ->with('NonUserRoleB', m::anyOf(true, false))
             ->andReturn(false);
-        $user->shouldReceive('can')
+        $user->shouldReceive('permission')
             ->with(m::anyOf('user_can_a', 'user_can_b', 'user_can_c'), m::anyOf(true, false))
             ->andReturn(true);
-        $user->shouldReceive('can')
+        $user->shouldReceive('permission')
             ->with('user_cannot_b', m::anyOf(true, false))
             ->andReturn(false);
 
@@ -790,10 +790,10 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         $user->shouldReceive('hasRole')
             ->with(m::anyOf($nonUserRoleNameA, $nonUserRoleNameB), m::anyOf(true, false))
             ->andReturn(false);
-        $user->shouldReceive('can')
+        $user->shouldReceive('permission')
             ->with(m::anyOf($userPermNameA, $userPermNameB, $userPermNameC), m::anyOf(true, false))
             ->andReturn(true);
-        $user->shouldReceive('can')
+        $user->shouldReceive('permission')
             ->with(m::anyOf($nonUserPermNameA, $nonUserPermNameB), m::anyOf(true, false))
             ->andReturn(false);
 
@@ -899,7 +899,7 @@ class EntrustUserTest extends PHPUnit_Framework_TestCase
         */
         $user->shouldReceive('hasRole')
             ->times(3);
-        $user->shouldReceive('can')
+        $user->shouldReceive('permission')
             ->times(3);
 
         /*


### PR DESCRIPTION
The 'can' method in the user trait is now in the core library, in order to use both functionalities, it is renamed to 'permission'.  
