### PR TITLE
Redirect back instead of (403) in middleware

### DIFF
--- a/src/Entrust/Middleware/EntrustRole.php
+++ b/src/Entrust/Middleware/EntrustRole.php
@@ -10,6 +10,7 @@
 
 use Closure;
 use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Support\Facades\Redirect;
 
 class EntrustRole
 {
@@ -42,7 +43,7 @@ class EntrustRole
 		}
 
 		if ($this->auth->guest() || !$request->user()->hasRole($roles)) {
-			return back();
+			return Redirect::back();
 		}
 
 		return $next($request);

--- a/src/Entrust/Middleware/EntrustRole.php
+++ b/src/Entrust/Middleware/EntrustRole.php
@@ -42,7 +42,7 @@ class EntrustRole
 		}
 
 		if ($this->auth->guest() || !$request->user()->hasRole($roles)) {
-			abort(403);
+			return back();
 		}
 
 		return $next($request);


### PR DESCRIPTION
Just modified to redirect back instead of throwing (403) error.