### PR TITLE
Add multiple auth when do not use Auth::user()

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ $role->forceDelete(); // Now force delete will work regardless of whether the pi
 
 #### Custom configuration - add multiple auth
 
-when you do not use Auth::user(), use another table(e.g. "admins"), this "auth" configuration item should be set up in the `config/entrust.php`. For example, when you use session(["admin_id" => $admin->id]) for background login verification, you may need this configuration.
+when you do not use Auth::user(), use another table(e.g. "admins"), this "auth" configuration item should be set up in the `config/entrust.php`. For example, when you use `session(["admin_id" => $admin->id])` for background login verification, you may need this configuration.
 
 ```php
     /*

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ contains the latest entrust version for Laravel 4.
 1) In order to install Laravel 5 Entrust, just add the following to your composer.json. Then run `composer update`:
 
 ```json
-"zizaco/entrust": "5.2.x-dev"
+"zizaco/entrust": "dev-master"
 ```
 
 2) Open your `config/app.php` and add the following to the `providers` array:
@@ -82,6 +82,26 @@ php artisan vendor:publish
 ```
 
 to `routeMiddleware` array in `app/Http/Kernel.php`.
+
+7) Custom configuration - add multiple auth
+
+when you do not use Auth::user(), use another table(e.g. "admins"), this "auth" configuration item should be set up in the `config/entrust.php`. For example, when you use `session(["admin_id" => $admin->id])` for background login verification, you may need this configuration.
+
+```php
+    /*
+    |--------------------------------------------------------------------------
+    | Custom configuration
+    |--------------------------------------------------------------------------
+    |
+    | when do not use Auth::user(), use another table(e.g. "admins"), this "auth"
+    | configuration item should be set up.
+    |
+    */
+    'auth' => [
+        'model' => App\Models\Admin::class,
+        'user_id_in_session' => 'admin_id',
+    ],
+```
 
 ## Configuration
 
@@ -197,26 +217,6 @@ $role->users()->sync([]); // Delete relationship data
 $role->perms()->sync([]); // Delete relationship data
 
 $role->forceDelete(); // Now force delete will work regardless of whether the pivot table has cascading delete
-```
-
-#### Custom configuration - add multiple auth
-
-when you do not use Auth::user(), use another table(e.g. "admins"), this "auth" configuration item should be set up in the `config/entrust.php`. For example, when you use `session(["admin_id" => $admin->id])` for background login verification, you may need this configuration.
-
-```php
-    /*
-    |--------------------------------------------------------------------------
-    | Custom configuration
-    |--------------------------------------------------------------------------
-    |
-    | when do not use Auth::user(), use another table(e.g. "admins"), this "auth"
-    | configuration item should be set up.
-    |
-    */
-    'auth' => [
-        'model' => App\Models\Admin::class,
-        'user_id_in_session' => 'admin_id',
-    ],
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ $role->forceDelete(); // Now force delete will work regardless of whether the pi
 
 #### Custom configuration - add multiple auth
 
-when you do not use Auth::user(), use another table(e.g. "admins"), this "auth" configuration item should be set up in the `config/entrust.php`. For example, when you use session('admin_id', $admin->id) for background login verification, you may need this configuration.
+when you do not use Auth::user(), use another table(e.g. "admins"), this "auth" configuration item should be set up in the `config/entrust.php`. For example, when you use session(["admin_id" => $admin->id]) for background login verification, you may need this configuration.
 
 ```php
     /*

--- a/README.md
+++ b/README.md
@@ -199,6 +199,26 @@ $role->perms()->sync([]); // Delete relationship data
 $role->forceDelete(); // Now force delete will work regardless of whether the pivot table has cascading delete
 ```
 
+#### Custom configuration - add multiple auth
+
+when you do not use Auth::user(), use another table(e.g. "admins"), this "auth" configuration item should be set up in the `config/entrust.php`. For example, when you use session('admin_id', $admin->id) for background login verification, you may need this configuration.
+
+```php
+    /*
+    |--------------------------------------------------------------------------
+    | Custom configuration
+    |--------------------------------------------------------------------------
+    |
+    | when do not use Auth::user(), use another table(e.g. "admins"), this "auth"
+    | configuration item should be set up.
+    |
+    */
+    'auth' => [
+        'model' => App\Models\Admin::class,
+        'user_id_in_session' => 'admin_id',
+    ],
+```
+
 ## Usage
 
 ### Concepts

--- a/src/Entrust/Entrust.php
+++ b/src/Entrust/Entrust.php
@@ -8,6 +8,8 @@
  * @package Zizaco\Entrust
  */
 
+use Illuminate\Support\Facades\Config;
+
 class Entrust
 {
     /**
@@ -87,10 +89,10 @@ class Entrust
     public function user()
     {
         //when do not use Auth::user(), use another table(e.g. "admins")
-        if(!empty(config('entrust.auth'))){
-            $userModelName = config('entrust.auth.model');
+        if(!empty(Config::get('entrust.auth'))){
+            $userModelName = Config::get('entrust.auth.model');
             $userModel = new $userModelName();
-            $user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
+            $user = $userModel->where('id', session(Config::get('entrust.auth.user_id_in_session')))->first();
             return $user;
         }else{
             //default

--- a/src/Entrust/Entrust.php
+++ b/src/Entrust/Entrust.php
@@ -86,7 +86,16 @@ class Entrust
      */
     public function user()
     {
-        return $this->app->auth->user();
+        //when do not use Auth::user(), use another table(e.g. "admins")
+        if(!empty(config('entrust.auth'))){
+            $userModelName = config('entrust.auth.model');
+            $userModel = new $userModelName();
+            $user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
+            return $user;
+        }else{
+            //default
+            return $this->app->auth->user();
+        }
     }
 
     /**

--- a/src/Entrust/Middleware/EntrustAbility.php
+++ b/src/Entrust/Middleware/EntrustAbility.php
@@ -51,9 +51,20 @@ class EntrustAbility
 			$validateAll = filter_var($validateAll, FILTER_VALIDATE_BOOLEAN);
 		}
 
-		if ($this->auth->guest() || !$request->user()->ability($roles, $permissions, [ 'validate_all' => $validateAll ])) {
-			abort(403);
-		}
+		//when do not use Auth::user(), use another table(e.g. "admins")
+		if(!empty(config('entrust.auth'))){
+            $userModelName = config('entrust.auth.model');
+            $userModel = new $userModelName();
+            $user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
+            if (empty($user) || !$user->ability($roles, $permissions, [ 'validate_all' => $validateAll ])) {
+				abort(403);
+			}
+        }else{
+            //default
+            if ($this->auth->guest() || !$request->user()->ability($roles, $permissions, [ 'validate_all' => $validateAll ])) {
+				abort(403);
+			}
+        }
 
 		return $next($request);
 	}

--- a/src/Entrust/Middleware/EntrustAbility.php
+++ b/src/Entrust/Middleware/EntrustAbility.php
@@ -10,6 +10,7 @@
 
 use Closure;
 use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Support\Facades\Config;
 
 class EntrustAbility
 {
@@ -52,10 +53,10 @@ class EntrustAbility
 		}
 
 		//when do not use Auth::user(), use another table(e.g. "admins")
-		if(!empty(config('entrust.auth'))){
-			$userModelName = config('entrust.auth.model');
+		if(!empty(Config::get('entrust.auth'))){
+			$userModelName = Config::get('entrust.auth.model');
 			$userModel = new $userModelName();
-			$user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
+			$user = $userModel->where('id', session(Config::get('entrust.auth.user_id_in_session')))->first();
 			if (empty($user) || !$user->ability($roles, $permissions, [ 'validate_all' => $validateAll ])) {
 				abort(403);
 			}

--- a/src/Entrust/Middleware/EntrustAbility.php
+++ b/src/Entrust/Middleware/EntrustAbility.php
@@ -53,18 +53,18 @@ class EntrustAbility
 
 		//when do not use Auth::user(), use another table(e.g. "admins")
 		if(!empty(config('entrust.auth'))){
-            $userModelName = config('entrust.auth.model');
-            $userModel = new $userModelName();
-            $user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
-            if (empty($user) || !$user->ability($roles, $permissions, [ 'validate_all' => $validateAll ])) {
+			$userModelName = config('entrust.auth.model');
+			$userModel = new $userModelName();
+			$user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
+			if (empty($user) || !$user->ability($roles, $permissions, [ 'validate_all' => $validateAll ])) {
 				abort(403);
 			}
-        }else{
-            //default
-            if ($this->auth->guest() || !$request->user()->ability($roles, $permissions, [ 'validate_all' => $validateAll ])) {
+		}else{
+			//default
+			if ($this->auth->guest() || !$request->user()->ability($roles, $permissions, [ 'validate_all' => $validateAll ])) {
 				abort(403);
 			}
-        }
+		}
 
 		return $next($request);
 	}

--- a/src/Entrust/Middleware/EntrustPermission.php
+++ b/src/Entrust/Middleware/EntrustPermission.php
@@ -10,6 +10,7 @@
 
 use Closure;
 use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Support\Facades\Config;
 
 class EntrustPermission
 {
@@ -42,10 +43,10 @@ class EntrustPermission
 		}
 
 		//when do not use Auth::user(), use another table(e.g. "admins")
-		if(!empty(config('entrust.auth'))){
-			$userModelName = config('entrust.auth.model');
+		if(!empty(Config::get('entrust.auth'))){
+			$userModelName = Config::get('entrust.auth.model');
 			$userModel = new $userModelName();
-			$user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
+			$user = $userModel->where('id', session(Config::get('entrust.auth.user_id_in_session')))->first();
 			if (empty($user) || !$user->can($permissions)) {
 				abort(403);
 			}

--- a/src/Entrust/Middleware/EntrustPermission.php
+++ b/src/Entrust/Middleware/EntrustPermission.php
@@ -41,9 +41,20 @@ class EntrustPermission
 			$permissions = explode(self::DELIMITER, $permissions);
 		}
 
-		if ($this->auth->guest() || !$request->user()->can($permissions)) {
-			abort(403);
-		}
+		//when do not use Auth::user(), use another table(e.g. "admins")
+		if(!empty(config('entrust.auth'))){
+            $userModelName = config('entrust.auth.model');
+            $userModel = new $userModelName();
+            $user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
+            if (empty($user) || !$user->can($permissions)) {
+				abort(403);
+			}
+        }else{
+            //default
+            if ($this->auth->guest() || !$request->user()->can($permissions)) {
+				abort(403);
+			}
+        }
 
 		return $next($request);
 	}

--- a/src/Entrust/Middleware/EntrustPermission.php
+++ b/src/Entrust/Middleware/EntrustPermission.php
@@ -43,18 +43,18 @@ class EntrustPermission
 
 		//when do not use Auth::user(), use another table(e.g. "admins")
 		if(!empty(config('entrust.auth'))){
-            $userModelName = config('entrust.auth.model');
-            $userModel = new $userModelName();
-            $user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
-            if (empty($user) || !$user->can($permissions)) {
+			$userModelName = config('entrust.auth.model');
+			$userModel = new $userModelName();
+			$user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
+			if (empty($user) || !$user->can($permissions)) {
 				abort(403);
 			}
-        }else{
-            //default
-            if ($this->auth->guest() || !$request->user()->can($permissions)) {
+		}else{
+			//default
+			if ($this->auth->guest() || !$request->user()->can($permissions)) {
 				abort(403);
 			}
-        }
+		}
 
 		return $next($request);
 	}

--- a/src/Entrust/Middleware/EntrustRole.php
+++ b/src/Entrust/Middleware/EntrustRole.php
@@ -41,9 +41,20 @@ class EntrustRole
 			$roles = explode(self::DELIMITER, $roles);
 		}
 
-		if ($this->auth->guest() || !$request->user()->hasRole($roles)) {
-			abort(403);
-		}
+		//when do not use Auth::user(), use another table(e.g. "admins")
+		if(!empty(config('entrust.auth'))){
+            $userModelName = config('entrust.auth.model');
+            $userModel = new $userModelName();
+            $user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
+            if (empty($user) || !$user->hasRole($roles)) {
+				abort(403);
+			}
+        }else{
+            //default
+            if ($this->auth->guest() || !$request->user()->hasRole($roles)) {
+				abort(403);
+			}
+        }
 
 		return $next($request);
 	}

--- a/src/Entrust/Middleware/EntrustRole.php
+++ b/src/Entrust/Middleware/EntrustRole.php
@@ -43,18 +43,18 @@ class EntrustRole
 
 		//when do not use Auth::user(), use another table(e.g. "admins")
 		if(!empty(config('entrust.auth'))){
-            $userModelName = config('entrust.auth.model');
-            $userModel = new $userModelName();
-            $user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
-            if (empty($user) || !$user->hasRole($roles)) {
+			$userModelName = config('entrust.auth.model');
+			$userModel = new $userModelName();
+			$user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
+			if (empty($user) || !$user->hasRole($roles)) {
 				abort(403);
 			}
-        }else{
-            //default
-            if ($this->auth->guest() || !$request->user()->hasRole($roles)) {
+		}else{
+			//default
+			if ($this->auth->guest() || !$request->user()->hasRole($roles)) {
 				abort(403);
 			}
-        }
+		}
 
 		return $next($request);
 	}

--- a/src/Entrust/Middleware/EntrustRole.php
+++ b/src/Entrust/Middleware/EntrustRole.php
@@ -10,6 +10,7 @@
 
 use Closure;
 use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Support\Facades\Config;
 
 class EntrustRole
 {
@@ -42,10 +43,10 @@ class EntrustRole
 		}
 
 		//when do not use Auth::user(), use another table(e.g. "admins")
-		if(!empty(config('entrust.auth'))){
-			$userModelName = config('entrust.auth.model');
+		if(!empty(Config::get('entrust.auth'))){
+			$userModelName = Config::get('entrust.auth.model');
 			$userModel = new $userModelName();
-			$user = $userModel->where('id', session(config('entrust.auth.user_id_in_session')))->first();
+			$user = $userModel->where('id', session(Config::get('entrust.auth.user_id_in_session')))->first();
 			if (empty($user) || !$user->hasRole($roles)) {
 				abort(403);
 			}


### PR DESCRIPTION
when you do not use Auth::user(), use another table(e.g. "admins"). For example, when you use `session(["admin_id" => $admin->id])` for background login verification, you may need this configuration. And  the "auth" configuration item should be set up in the `config/entrust.php`.