### PR TITLE
Use bootTrait() methods instead of generic boot()

### DIFF
--- a/src/Entrust/Traits/EntrustPermissionTrait.php
+++ b/src/Entrust/Traits/EntrustPermissionTrait.php
@@ -29,10 +29,8 @@ trait EntrustPermissionTrait
      *
      * @return void|bool
      */
-    public static function boot()
+    public static function bootEntrustPermissionTrait()
     {
-        parent::boot();
-
         static::deleting(function($permission) {
             if (!method_exists(Config::get('entrust.permission'), 'bootSoftDeletes')) {
                 $permission->roles()->sync([]);

--- a/src/Entrust/Traits/EntrustRoleTrait.php
+++ b/src/Entrust/Traits/EntrustRoleTrait.php
@@ -87,10 +87,8 @@ trait EntrustRoleTrait
      *
      * @return void|bool
      */
-    public static function boot()
+    public static function bootEntrustRoleTrait()
     {
-        parent::boot();
-
         static::deleting(function ($role) {
             if (!method_exists(Config::get('entrust.role'), 'bootSoftDeletes')) {
                 $role->users()->sync([]);

--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -66,10 +66,8 @@ trait EntrustUserTrait
      *
      * @return void|bool
      */
-    public static function boot()
+    public static function bootEntrustUserTrait()
     {
-        parent::boot();
-
         static::deleting(function($user) {
             if (!method_exists(Config::get('auth.model'), 'bootSoftDeletes')) {
                 $user->roles()->sync([]);

--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -32,7 +32,7 @@ class MigrationCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->laravel->view->addNamespace('entrust', substr(__DIR__, 0, -8).'views');
 


### PR DESCRIPTION
This commit could resolve the issue where the boot() method is defined in same class as the Entrust trait usage (which can cause conflict), and is more "Laravel way" to perform trait boot instead of generic boot().