### PR TITLE
adds trusty distribution to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.5
   - 5.6


### PR DESCRIPTION
> HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.

adds trusty distribution to travis config for hhvm build error.