### PR TITLE
Use laravel cache key (to allow multiple apps to use the same caching server)

### DIFF
--- a/src/Entrust/Traits/EntrustRoleTrait.php
+++ b/src/Entrust/Traits/EntrustRoleTrait.php
@@ -20,7 +20,7 @@ trait EntrustRoleTrait
         $rolePrimaryKey = $this->primaryKey;
         $cacheKey = 'entrust_permissions_for_role_' . $this->$rolePrimaryKey;
         if (Cache::getStore() instanceof TaggableStore) {
-            return Cache::tags(Config::get('entrust.permission_role_table'))->remember($cacheKey, Config::get('cache.ttl', 60), function () {
+            return Cache::tags(Config::get('app.key').':'.Config::get('entrust.permission_role_table'))->remember($cacheKey, Config::get('cache.ttl', 60), function () {
                 return $this->perms()->get();
             });
         } else return $this->perms()->get();
@@ -32,7 +32,7 @@ trait EntrustRoleTrait
             return false;
         }
         if (Cache::getStore() instanceof TaggableStore) {
-            Cache::tags(Config::get('entrust.permission_role_table'))->flush();
+            Cache::tags(Config::get('app.key').':'.Config::get('entrust.permission_role_table'))->flush();
         }
         return true;
     }
@@ -43,7 +43,7 @@ trait EntrustRoleTrait
             return false;
         }
         if (Cache::getStore() instanceof TaggableStore) {
-            Cache::tags(Config::get('entrust.permission_role_table'))->flush();
+            Cache::tags(Config::get('app.key').':'.Config::get('entrust.permission_role_table'))->flush();
         }
         return true;
     }
@@ -54,7 +54,7 @@ trait EntrustRoleTrait
             return false;
         }
         if (Cache::getStore() instanceof TaggableStore) {
-            Cache::tags(Config::get('entrust.permission_role_table'))->flush();
+            Cache::tags(Config::get('app.key').':'.Config::get('entrust.permission_role_table'))->flush();
         }
         return true;
     }

--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -21,7 +21,7 @@ trait EntrustUserTrait
         $userPrimaryKey = $this->primaryKey;
         $cacheKey = 'entrust_roles_for_user_'.$this->$userPrimaryKey;
         if(Cache::getStore() instanceof TaggableStore) {
-            return Cache::tags(Config::get('entrust.role_user_table'))->remember($cacheKey, Config::get('cache.ttl'), function () {
+            return Cache::tags(Config::get('app.key').':'.Config::get('entrust.role_user_table'))->remember($cacheKey, Config::get('cache.ttl'), function () {
                 return $this->roles()->get();
             });
         }
@@ -30,7 +30,7 @@ trait EntrustUserTrait
     public function save(array $options = [])
     {   //both inserts and updates
         if(Cache::getStore() instanceof TaggableStore) {
-            Cache::tags(Config::get('entrust.role_user_table'))->flush();
+            Cache::tags(Config::get('app.key').':'.Config::get('entrust.role_user_table'))->flush();
         }
         return parent::save($options);
     }
@@ -38,14 +38,14 @@ trait EntrustUserTrait
     {   //soft or hard
         parent::delete($options);
         if(Cache::getStore() instanceof TaggableStore) {
-            Cache::tags(Config::get('entrust.role_user_table'))->flush();
+            Cache::tags(Config::get('app.key').':'.Config::get('entrust.role_user_table'))->flush();
         }
     }
     public function restore()
     {   //soft delete undo's
         parent::restore();
         if(Cache::getStore() instanceof TaggableStore) {
-            Cache::tags(Config::get('entrust.role_user_table'))->flush();
+            Cache::tags(Config::get('app.key').':'.Config::get('entrust.role_user_table'))->flush();
         }
     }
 


### PR DESCRIPTION
These commits fixes the key stored in the cache to match laravel conventions.
This is important when you have multiple Laravel apps using the same caching server, because they override one another.