### PR TITLE
Changed fire method to handle to meet Laravel's 5.5 requirements

### DIFF
--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -32,7 +32,7 @@ class MigrationCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->laravel->view->addNamespace('entrust', substr(__DIR__, 0, -8).'views');
 


### PR DESCRIPTION
When executing the entrust:migration command, an error is thrown on L5.5:
Method Zizaco\Entrust\MigrationCommand::handle() does not exist

Changed MigrationCommand's fire() method to handle()