### PR TITLE
Rename method fire to handle, avoiding error on laravel 5.5

### DIFF
--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -32,7 +32,7 @@ class MigrationCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->laravel->view->addNamespace('entrust', substr(__DIR__, 0, -8).'views');
 


### PR DESCRIPTION
This is a necessary modification to make the entrust package works perfectly on laravel 5.5, because on this version the method fire was renamed.