### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ contains the latest entrust version for Laravel 4.
 1) In order to install Laravel 5 Entrust, just add the following to your composer.json. Then run `composer update`:
 
 ```json
-"zizaco/entrust": "5.2.x-dev"
+"zizaco/entrust": "dev-master"
 ```
 
 2) Open your `config/app.php` and add the following to the `providers` array:


### PR DESCRIPTION
5.2.x-dev creates an Error: Method Zizaco\Entrust\MigrationCommand::handle() does not exist on Laravel 5.5. when creating migrations: php artisan entrust:migration

<img width="692" alt="screen shot 2018-02-14 at 01 41 48" src="https://user-images.githubusercontent.com/13575726/36170534-d54667e4-1129-11e8-9f5e-c1d582611dbd.png">
