### PR TITLE
add entrust.cache_ttl config to replace cache.ttl

### DIFF
--- a/src/Entrust/Traits/EntrustRoleTrait.php
+++ b/src/Entrust/Traits/EntrustRoleTrait.php
@@ -20,7 +20,7 @@ trait EntrustRoleTrait
         $rolePrimaryKey = $this->primaryKey;
         $cacheKey = 'entrust_permissions_for_role_' . $this->$rolePrimaryKey;
         if (Cache::getStore() instanceof TaggableStore) {
-            return Cache::tags(Config::get('entrust.permission_role_table'))->remember($cacheKey, Config::get('cache.ttl', 60), function () {
+            return Cache::tags(Config::get('entrust.permission_role_table'))->remember($cacheKey, Config::get('entrust.cache_ttl', 60), function () {
                 return $this->perms()->get();
             });
         } else return $this->perms()->get();

--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -25,7 +25,7 @@ trait EntrustUserTrait
         $userPrimaryKey = $this->primaryKey;
         $cacheKey = 'entrust_roles_for_user_'.$this->$userPrimaryKey;
         if(Cache::getStore() instanceof TaggableStore) {
-            return Cache::tags(Config::get('entrust.role_user_table'))->remember($cacheKey, Config::get('cache.ttl'), function () {
+            return Cache::tags(Config::get('entrust.role_user_table'))->remember($cacheKey, Config::get('entrust.cache_ttl', 60), function () {
                 return $this->roles()->get();
             });
         }
@@ -305,7 +305,7 @@ trait EntrustUserTrait
     }
 
     /**
-     *Filtering users according to their role 
+     *Filtering users according to their role
      *
      *@param string $role
      *@return users collection

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -129,4 +129,15 @@ return [
     |
     */
     'permission_foreign_key' => 'permission_id',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Entrust Cache TTL
+    |--------------------------------------------------------------------------
+    |
+    | This is the TTL (in minutes) used by Entrust to cache roles and
+    | permissions
+    |
+    */
+    'cache_ttl' => 60
 ];


### PR DESCRIPTION
Add entrust.cache_ttl as default TTL value for permission and role so package will work out of the box. Since cache.ttl is not a default laravel configuration.