### PR TITLE
fix migration ,change the migration  #d1a0d96

### DIFF
--- a/src/views/generators/migration.blade.php
+++ b/src/views/generators/migration.blade.php
@@ -12,8 +12,9 @@ class EntrustSetupTables extends Migration
      */
     public function up()
     {
-        DB::beginTransaction();
-
+        
+       try{
+       
         // Create table for storing roles
         Schema::create('{{ $rolesTable }}', function (Blueprint $table) {
             $table->increments('id');
@@ -56,9 +57,13 @@ class EntrustSetupTables extends Migration
                 ->onUpdate('cascade')->onDelete('cascade');
 
             $table->primary(['permission_id', 'role_id']);
-        });
+         });
+        } catch (\Exception $err) {
+            $this->down();
+            throw $err;
+        }
 
-        DB::commit();
+        
     }
 
     /**
@@ -68,9 +73,9 @@ class EntrustSetupTables extends Migration
      */
     public function down()
     {
-        Schema::drop('{{ $permissionRoleTable }}');
-        Schema::drop('{{ $permissionsTable }}');
-        Schema::drop('{{ $roleUserTable }}');
-        Schema::drop('{{ $rolesTable }}');
+        Schema::dropIfExists('{{ $permissionRoleTable }}');
+        Schema::dropIfExists('{{ $permissionsTable }}');
+        Schema::dropIfExists('{{ $roleUserTable }}');
+        Schema::dropIfExists('{{ $rolesTable }}');
     }
 }


### PR DESCRIPTION
Remove the transaction sentence, because it's a wrong usage and it dose not work in
mysql DDL action,it may cause an implicit commit. See 
detail info in [mysql-de-refman](https://dev.mysql.com/doc/refman/5.7/en/implicit-commit.html) 
Change drop() to dropIfExists() function to avoid none tables exceptions

Closes #678